### PR TITLE
Improve memory usage by serializing the response object directly

### DIFF
--- a/endpoints-framework/src/main/java/com/google/api/server/spi/ServletInitializationParameters.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/ServletInitializationParameters.java
@@ -38,6 +38,7 @@ public abstract class ServletInitializationParameters {
   private static final String ILLEGAL_ARGUMENT_BACKEND_ERROR = "illegalArgumentIsBackendError";
   private static final String EXCEPTION_COMPATIBILITY = "enableExceptionCompatibility";
   private static final String PRETTY_PRINT = "prettyPrint";
+  private static final String ADD_CONTENT_LENGTH = "addContentLength";
 
   private static final Splitter CSV_SPLITTER = Splitter.on(',').omitEmptyStrings().trimResults();
   private static final Joiner CSV_JOINER = Joiner.on(',').skipNulls();
@@ -83,13 +84,22 @@ public abstract class ServletInitializationParameters {
    */
   public abstract boolean isPrettyPrintEnabled();
 
+  /**
+   * Returns if the Content-Length header should be set on response. Should be disabled when running
+   * on App Engine, as Content-Length header is discarded by front-end servers. If enabled, has a
+   * small negative impact on CPU usage and latency.
+   *
+   */
+  public abstract boolean isAddContentLength();
+
   public static Builder builder() {
     return new AutoValue_ServletInitializationParameters.Builder()
         .setServletRestricted(true)
         .setClientIdWhitelistEnabled(true)
         .setIllegalArgumentBackendError(false)
         .setExceptionCompatibilityEnabled(true)
-        .setPrettyPrintEnabled(true);
+        .setPrettyPrintEnabled(true)
+        .setAddContentLength(false);
   }
 
   /**
@@ -160,6 +170,11 @@ public abstract class ServletInitializationParameters {
      */
     public abstract Builder setPrettyPrintEnabled(boolean prettyPrint);
 
+    /**
+     * Sets if the content length header should be set. Defaults to {@code false}.
+     */
+    public abstract Builder setAddContentLength(boolean addContentLength);
+
     abstract ServletInitializationParameters autoBuild();
 
     public ServletInitializationParameters build() {
@@ -203,6 +218,10 @@ public abstract class ServletInitializationParameters {
       if (prettyPrint != null) {
         builder.setPrettyPrintEnabled(parseBoolean(prettyPrint, PRETTY_PRINT));
       }
+      String addContentLength = config.getInitParameter(ADD_CONTENT_LENGTH);
+      if (addContentLength != null) {
+        builder.setAddContentLength(parseBoolean(addContentLength, ADD_CONTENT_LENGTH));
+      }
     }
     return builder.build();
   }
@@ -238,6 +257,7 @@ public abstract class ServletInitializationParameters {
         .put(ILLEGAL_ARGUMENT_BACKEND_ERROR, Boolean.toString(isIllegalArgumentBackendError()))
         .put(EXCEPTION_COMPATIBILITY, Boolean.toString(isExceptionCompatibilityEnabled()))
         .put(PRETTY_PRINT, Boolean.toString(isPrettyPrintEnabled()))
+        .put(ADD_CONTENT_LENGTH, Boolean.toString(isAddContentLength()))
         .build();
   }
 }

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/handlers/EndpointsMethodHandler.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/handlers/EndpointsMethodHandler.java
@@ -91,6 +91,7 @@ public class EndpointsMethodHandler {
       ApiSerializationConfig serializationConfig) {
     return new RestResponseResultWriter(context.getResponse(), serializationConfig,
         StandardParameters.shouldPrettyPrint(context),
+        initParameters.isAddContentLength(),
         initParameters.isExceptionCompatibilityEnabled());
   }
 

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/response/RestResponseResultWriter.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/response/RestResponseResultWriter.java
@@ -16,14 +16,11 @@
 package com.google.api.server.spi.response;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.api.server.spi.ObjectMapperUtil;
 import com.google.api.server.spi.ServiceException;
 import com.google.api.server.spi.config.model.ApiSerializationConfig;
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 
 import java.io.IOException;
 
@@ -39,8 +36,8 @@ public class RestResponseResultWriter extends ServletResponseResultWriter {
 
   public RestResponseResultWriter(
       HttpServletResponse servletResponse, ApiSerializationConfig serializationConfig,
-      boolean prettyPrint, boolean enableExceptionCompatibility) {
-    super(servletResponse, serializationConfig, prettyPrint);
+      boolean prettyPrint, boolean addContentLength, boolean enableExceptionCompatibility) {
+    super(servletResponse, serializationConfig, prettyPrint, addContentLength);
     this.enableExceptionCompatibility = enableExceptionCompatibility;
     this.objectMapper = ObjectMapperUtil.createStandardObjectMapper(serializationConfig);
   }
@@ -70,8 +67,7 @@ public class RestResponseResultWriter extends ServletResponseResultWriter {
         e.getReason() : errorMap.getReason(e.getStatusCode());
     String domain = !Strings.isNullOrEmpty(e.getDomain()) ?
         e.getDomain() : errorMap.getDomain(e.getStatusCode());
-    write(code, e.getHeaders(),
-        writeValueAsString(createError(code, reason, domain, e.getMessage())));
+    write(code, e.getHeaders(), createError(code, reason, domain, e.getMessage()));
   }
 
   private Object createError(int code, String reason, String domain, String message) {

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/EndpointsServletTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/EndpointsServletTest.java
@@ -114,6 +114,33 @@ public class EndpointsServletTest {
   }
 
   @Test
+  public void contentLengthHeaderNull() throws IOException {
+    req.setRequestURI("/_ah/api/test/v2/echo");
+    req.setMethod("POST");
+    req.setParameter("x", "1");
+
+    servlet.service(req, resp);
+
+    assertThat(resp.getHeader("Content-Length")).isNull();
+  }
+
+  @Test
+  public void contentLengthHeaderPresent() throws IOException, ServletException {
+    MockServletConfig config = new MockServletConfig();
+    config.addInitParameter("services", TestApi.class.getName());
+    config.addInitParameter("addContentLength", "true");
+    servlet.init(config);
+
+    req.setRequestURI("/_ah/api/test/v2/echo");
+    req.setMethod("POST");
+    req.setParameter("x", "1");
+
+    servlet.service(req, resp);
+
+    assertThat(resp.getHeader("Content-Length")).isNotNull();
+  }
+
+  @Test
   public void methodOverride() throws IOException {
     req.setRequestURI("/_ah/api/test/v2/increment");
     req.setMethod("POST");

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/ServletInitializationParametersTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/ServletInitializationParametersTest.java
@@ -48,7 +48,8 @@ public class ServletInitializationParametersTest {
     assertThat(initParameters.isIllegalArgumentBackendError()).isFalse();
     assertThat(initParameters.isExceptionCompatibilityEnabled()).isTrue();
     assertThat(initParameters.isPrettyPrintEnabled()).isTrue();
-    verifyAsMap(initParameters, "", "true", "true", "false", "true", "true");
+    assertThat(initParameters.isAddContentLength()).isFalse();
+    verifyAsMap(initParameters, "", "true", "true", "false", "true", "true", "false");
   }
 
   @Test
@@ -60,13 +61,14 @@ public class ServletInitializationParametersTest {
         .setIllegalArgumentBackendError(true)
         .setExceptionCompatibilityEnabled(true)
         .setPrettyPrintEnabled(true)
+        .setAddContentLength(true)
         .build();
     assertThat(initParameters.getServiceClasses()).isEmpty();
     assertThat(initParameters.isServletRestricted()).isTrue();
     assertThat(initParameters.isClientIdWhitelistEnabled()).isTrue();
     assertThat(initParameters.isIllegalArgumentBackendError()).isTrue();
     assertThat(initParameters.isExceptionCompatibilityEnabled()).isTrue();
-    verifyAsMap(initParameters, "", "true", "true", "true", "true", "true");
+    verifyAsMap(initParameters, "", "true", "true", "true", "true", "true", "true");
   }
 
   @Test
@@ -78,12 +80,13 @@ public class ServletInitializationParametersTest {
         .setIllegalArgumentBackendError(false)
         .setExceptionCompatibilityEnabled(false)
         .setPrettyPrintEnabled(false)
+        .setAddContentLength(false)
         .build();
     assertThat(initParameters.getServiceClasses()).containsExactly(String.class);
     assertThat(initParameters.isServletRestricted()).isFalse();
     assertThat(initParameters.isClientIdWhitelistEnabled()).isFalse();
     verifyAsMap(
-        initParameters, String.class.getName(), "false", "false", "false", "false", "false");
+        initParameters, String.class.getName(), "false", "false", "false", "false", "false","false");
   }
 
   @Test
@@ -93,7 +96,7 @@ public class ServletInitializationParametersTest {
         .build();
     assertThat(initParameters.getServiceClasses()).containsExactly(String.class, Integer.class);
     verifyAsMap(initParameters, String.class.getName() + ',' + Integer.class.getName(), "true",
-        "true", "false", "true", "true");
+        "true", "false", "true", "true", "false");
   }
 
   @Test
@@ -108,7 +111,7 @@ public class ServletInitializationParametersTest {
   @Test
   public void testFromServletConfig_nullValues() throws ServletException {
     ServletInitializationParameters initParameters =
-        fromServletConfig(null, null, null, null, null, null);
+        fromServletConfig(null, null, null, null, null, null, null);
     assertThat(initParameters.getServiceClasses()).isEmpty();
     assertThat(initParameters.isServletRestricted()).isTrue();
     assertThat(initParameters.isClientIdWhitelistEnabled()).isTrue();
@@ -120,7 +123,7 @@ public class ServletInitializationParametersTest {
   @Test
   public void testFromServletConfig_emptySetsAndFalse() throws ServletException {
     ServletInitializationParameters initParameters =
-        fromServletConfig("", "false", "false", "false", "false", "false");
+        fromServletConfig("", "false", "false", "false", "false", "false", "false");
     assertThat(initParameters.getServiceClasses()).isEmpty();
     assertThat(initParameters.isServletRestricted()).isFalse();
     assertThat(initParameters.isClientIdWhitelistEnabled()).isFalse();
@@ -132,7 +135,7 @@ public class ServletInitializationParametersTest {
   @Test
   public void testFromServletConfig_oneEntrySetsAndTrue() throws ServletException {
     ServletInitializationParameters initParameters =
-        fromServletConfig(String.class.getName(), "true", "true", "true", "true", "true");
+        fromServletConfig(String.class.getName(), "true", "true", "true", "true", "true", "true");
     assertThat(initParameters.getServiceClasses()).containsExactly(String.class);
     assertThat(initParameters.isServletRestricted()).isTrue();
     assertThat(initParameters.isClientIdWhitelistEnabled()).isTrue();
@@ -144,7 +147,7 @@ public class ServletInitializationParametersTest {
   @Test
   public void testFromServletConfig_twoEntrySets() throws ServletException {
     ServletInitializationParameters initParameters = fromServletConfig(
-        String.class.getName() + ',' + Integer.class.getName(), null, null, null, null, null);
+        String.class.getName() + ',' + Integer.class.getName(), null, null, null, null, null, null);
     assertThat(initParameters.getServiceClasses()).containsExactly(String.class, Integer.class);
   }
 
@@ -152,14 +155,14 @@ public class ServletInitializationParametersTest {
   public void testFromServletConfig_skipsEmptyElements() throws ServletException {
     ServletInitializationParameters initParameters = fromServletConfig(
         ",," + String.class.getName() + ",,," + Integer.class.getName() + ",", null, null, null,
-        null, null);
+        null, null, null);
     assertThat(initParameters.getServiceClasses()).containsExactly(String.class, Integer.class);
   }
 
   @Test
   public void testFromServletConfig_invalidRestrictedThrows() throws ServletException {
     try {
-      fromServletConfig(null, "yes", null, null, null, null);
+      fromServletConfig(null, "yes", null, null, null, null, null);
       fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException expected) {
       // expected
@@ -170,25 +173,27 @@ public class ServletInitializationParametersTest {
       ServletInitializationParameters initParameters, String serviceClasses,
       String isServletRestricted, String isClientIdWhitelistEnabled,
       String isIllegalArgumentBackendError, String isExceptionCompatibilityEnabled,
-      String isPrettyPrintEnabled) {
+      String isPrettyPrintEnabled, String isAddContentLength) {
     Map<String, String> map = initParameters.asMap();
-    assertThat(map).hasSize(6);
+    assertThat(map).hasSize(7);
     assertThat(map.get("services")).isEqualTo(serviceClasses);
     assertThat(map.get("restricted")).isEqualTo(isServletRestricted);
     assertThat(map.get("clientIdWhitelistEnabled")).isEqualTo(isClientIdWhitelistEnabled);
     assertThat(map.get("illegalArgumentIsBackendError")).isEqualTo(isIllegalArgumentBackendError);
     assertThat(map.get("enableExceptionCompatibility")).isEqualTo(isExceptionCompatibilityEnabled);
     assertThat(map.get("prettyPrint")).isEqualTo(isPrettyPrintEnabled);
+    assertThat(map.get("addContentLength")).isEqualTo(isAddContentLength);
   }
 
   private ServletInitializationParameters fromServletConfig(
       String serviceClasses, String isServletRestricted,
       String isClientIdWhitelistEnabled, String isIllegalArgumentBackendError,
-      String isExceptionCompatibilityEnabled, String isPrettyPrintEnabled)
+      String isExceptionCompatibilityEnabled, String isPrettyPrintEnabled,
+      String isAddContentLength)
       throws ServletException {
     ServletConfig servletConfig = new StubServletConfig(serviceClasses,
         isServletRestricted, isClientIdWhitelistEnabled, isIllegalArgumentBackendError,
-        isExceptionCompatibilityEnabled, isPrettyPrintEnabled);
+        isExceptionCompatibilityEnabled, isPrettyPrintEnabled, isAddContentLength);
     return ServletInitializationParameters.fromServletConfig(
             servletConfig, getClass().getClassLoader());
   }
@@ -199,7 +204,7 @@ public class ServletInitializationParametersTest {
     public StubServletConfig(
         String serviceClasses, String isServletRestricted, String isClientIdWhitelistEnabled,
         String isIllegalArgumentBackendError, String isExceptionCompatibilityEnabled,
-        String isPrettyPrintEnabled) {
+        String isPrettyPrintEnabled, String isAddContentLength) {
       initParameters = Maps.newHashMap();
       initParameters.put("services", serviceClasses);
       initParameters.put("restricted", isServletRestricted);
@@ -207,6 +212,7 @@ public class ServletInitializationParametersTest {
       initParameters.put("illegalArgumentIsBackendError", isIllegalArgumentBackendError);
       initParameters.put("enableExceptionCompatibility", isExceptionCompatibilityEnabled);
       initParameters.put("prettyPrint", isPrettyPrintEnabled);
+      initParameters.put("addContentLength", isAddContentLength);
     }
 
     @Override

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/response/RestResponseResultWriterTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/response/RestResponseResultWriterTest.java
@@ -174,7 +174,8 @@ public class RestResponseResultWriterTest {
       boolean enableExceptionCompatibility) throws Exception {
     MockHttpServletResponse response = new MockHttpServletResponse();
     RestResponseResultWriter writer = new RestResponseResultWriter(
-        response, null, true /* prettyPrint */, enableExceptionCompatibility);
+        response, null, true /* prettyPrint */,
+        true /* addContentLength */, enableExceptionCompatibility);
     writer.writeError(new ServiceException(exceptionCode, message));
     ObjectMapper mapper = ObjectMapperUtil.createStandardObjectMapper();
     ObjectNode content = mapper.readValue(response.getContentAsString(), ObjectNode.class);
@@ -209,7 +210,8 @@ public class RestResponseResultWriterTest {
       String expectedReason, String customDomain, String expectedDomain) throws Exception {
     MockHttpServletResponse response = new MockHttpServletResponse();
     RestResponseResultWriter writer = new RestResponseResultWriter(
-            response, null, true /* prettyPrint */, enableExceptionCompatibility);
+            response, null, true /* prettyPrint */,
+        true /* addContentLength */, enableExceptionCompatibility);
     writer.writeError(new ServiceException(400, "error", customReason, customDomain));
     ObjectMapper mapper = ObjectMapperUtil.createStandardObjectMapper();
     ObjectNode content = mapper.readValue(response.getContentAsString(), ObjectNode.class);

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/response/ServletResponseResultWriterTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/response/ServletResponseResultWriterTest.java
@@ -172,7 +172,7 @@ public class ServletResponseResultWriterTest {
   public void testPrettyPrint() throws Exception {
     MockHttpServletResponse response = new MockHttpServletResponse();
     ServletResponseResultWriter writer = new ServletResponseResultWriter(response, null,
-        true /* prettyPrint */);
+        true /* prettyPrint */, true /* addContentLength */);
     writer.write(ImmutableMap.of("one", "two", "three", "four"));
     // If the response is pretty printed, there should be at least two newlines.
     String body = response.getContentAsString();


### PR DESCRIPTION
- Prevents an intermediate String (sometimes big) from being created
- Activated with the streamResponse=true servlet init parameter