### PR TITLE
Fix inconsistent enum constant names between schema and serialization

### DIFF
--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/SchemaRepository.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/SchemaRepository.java
@@ -2,7 +2,6 @@ package com.google.api.server.spi.config.model;
 
 import com.google.api.client.util.Maps;
 import com.google.api.server.spi.TypeLoader;
-import com.google.api.server.spi.config.Description;
 import com.google.api.server.spi.config.ResourcePropertySchema;
 import com.google.api.server.spi.config.ResourceSchema;
 import com.google.api.server.spi.config.annotationreader.ApiAnnotationIntrospector;
@@ -18,7 +17,6 @@ import com.google.common.collect.Multimap;
 import com.google.common.reflect.TypeToken;
 
 import java.util.EnumSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -172,15 +170,13 @@ public class SchemaRepository {
       schemaByApiKeys.put(key, schema);
       return schema;
     } else if (Types.isEnumType(type)) {
+      Map<String, String> valuesAndDescriptions = Types.getEnumValuesAndDescriptions(type);
       Schema.Builder builder = Schema.builder()
           .setName(Types.getSimpleName(type, config.getSerializationConfig()))
           .setType("string");
-      for (java.lang.reflect.Field field : type.getRawType().getFields()) {
-        if (field.isEnumConstant()) {
-          builder.addEnumValue(field.getName());
-          Description description = field.getAnnotation(Description.class);
-          builder.addEnumDescription(description == null ? "" : description.value());
-        }
+      for (Entry<String, String> entry : valuesAndDescriptions.entrySet()) {
+        builder.addEnumValue(entry.getKey());
+        builder.addEnumDescription(entry.getValue());
       }
       schema = builder.build();
       typesForConfig.put(type, schema);

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/discovery/DiscoveryGenerator.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/discovery/DiscoveryGenerator.java
@@ -20,7 +20,6 @@ import com.google.api.client.util.Preconditions;
 import com.google.api.server.spi.ObjectMapperUtil;
 import com.google.api.server.spi.Strings;
 import com.google.api.server.spi.TypeLoader;
-import com.google.api.server.spi.config.Description;
 import com.google.api.server.spi.config.annotationreader.ApiAnnotationIntrospector;
 import com.google.api.server.spi.config.model.ApiConfig;
 import com.google.api.server.spi.config.model.ApiKey;
@@ -34,6 +33,7 @@ import com.google.api.server.spi.config.model.Schema.Field;
 import com.google.api.server.spi.config.model.SchemaRepository;
 import com.google.api.server.spi.config.model.AuthScopeRepository;
 import com.google.api.server.spi.config.model.StandardParameters;
+import com.google.api.server.spi.config.model.Types;
 import com.google.api.server.spi.config.scope.AuthScopeExpression;
 import com.google.api.server.spi.config.scope.AuthScopeExpressions;
 import com.google.api.services.discovery.model.DirectoryList;
@@ -363,14 +363,13 @@ public class DiscoveryGenerator {
     }
 
     if (parameterConfig.isEnum()) {
+      Map<String, String> enumValuesAndDescriptions = Types
+          .getEnumValuesAndDescriptions((TypeToken<Enum<?>>) type);
       List<String> enumValues = Lists.newArrayList();
       List<String> enumDescriptions = Lists.newArrayList();
-      for (java.lang.reflect.Field field : type.getRawType().getFields()) {
-        if (field.isEnumConstant()) {
-          enumValues.add(field.getName());
-          Description description = field.getAnnotation(Description.class);
-          enumDescriptions.add(description == null ? "" : description.value());
-        }
+      for (Entry<String, String> entry : enumValuesAndDescriptions.entrySet()) {
+        enumValues.add(entry.getKey());
+        enumDescriptions.add(entry.getValue());
       }
       schema.setEnum(enumValues);
       schema.setEnumDescriptions(enumDescriptions);

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/SwaggerGenerator.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/SwaggerGenerator.java
@@ -33,6 +33,7 @@ import com.google.api.server.spi.config.model.FieldType;
 import com.google.api.server.spi.config.model.Schema;
 import com.google.api.server.spi.config.model.Schema.Field;
 import com.google.api.server.spi.config.model.SchemaRepository;
+import com.google.api.server.spi.config.model.Types;
 import com.google.api.server.spi.config.validation.ApiConfigValidator;
 import com.google.api.server.spi.types.DateAndTime;
 import com.google.api.server.spi.types.SimpleDate;
@@ -487,11 +488,7 @@ public class SwaggerGenerator {
   }
 
   private static List<String> getEnumValues(TypeToken<?> t) {
-    List<String> values = Lists.newArrayList();
-    for (Object value : t.getRawType().getEnumConstants()) {
-      values.add(value.toString());
-    }
-    return values;
+    return new ArrayList<>(Types.getEnumValuesAndDescriptions((TypeToken<Enum<?>>) t).keySet());
   }
 
   private static SecuritySchemeDefinition toScheme(

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/config/model/SchemaRepositoryTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/config/model/SchemaRepositoryTest.java
@@ -226,10 +226,28 @@ public class SchemaRepositoryTest {
             .setName("TestEnum")
             .setType("string")
             .addEnumValue("VALUE1")
-            .addEnumValue("VALUE2")
+            .addEnumValue("value_2")
             .addEnumDescription("")
             .addEnumDescription("")
             .build());
+  }
+
+  @Test
+  public void getOrAdd_enum_disableJacksonAnnotations() throws Exception {
+    System.setProperty(EndpointsFlag.JSON_USE_JACKSON_ANNOTATIONS.systemPropertyName, "false");
+    try {
+      assertThat(repo.getOrAdd(TypeToken.of(TestEnum.class), config))
+          .isEqualTo(Schema.builder()
+              .setName("TestEnum")
+              .setType("string")
+              .addEnumValue("VALUE1")
+              .addEnumValue("VALUE2")
+              .addEnumDescription("")
+              .addEnumDescription("")
+              .build());
+    } finally {
+      System.clearProperty(EndpointsFlag.JSON_USE_JACKSON_ANNOTATIONS.systemPropertyName);
+    }
   }
 
   @Test
@@ -270,7 +288,7 @@ public class SchemaRepositoryTest {
             .setName("TestEnum")
             .setType("string")
             .addEnumValue("VALUE1")
-            .addEnumValue("VALUE2")
+            .addEnumValue("value_2")
             .addEnumDescription("")
             .addEnumDescription("")
             .build(),

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/discovery/enum_endpoint.json
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/discovery/enum_endpoint.json
@@ -30,7 +30,7 @@
         "value": {
           "enum": [
             "VALUE1",
-            "VALUE2"
+            "value_2"
           ],
           "enumDescriptions": [
             "",
@@ -110,7 +110,7 @@
     },
     "TestEnum": {
       "id": "TestEnum",
-      "enum" : [ "VALUE1", "VALUE2" ],
+      "enum" : [ "VALUE1", "value_2" ],
       "enumDescriptions" : [ "", "" ],
       "type": "string"
     }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/enum_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/enum_endpoint.swagger
@@ -27,7 +27,7 @@
             "type": "string",
             "enum": [
               "VALUE1",
-              "VALUE2"
+              "value_2"
             ]
           }
         ],
@@ -50,7 +50,7 @@
           "type": "string",
           "enum": [
             "VALUE1",
-            "VALUE2"
+            "value_2"
           ]
         }
       }

--- a/test-utils/src/main/java/com/google/api/server/spi/testing/TestEnum.java
+++ b/test-utils/src/main/java/com/google/api/server/spi/testing/TestEnum.java
@@ -15,6 +15,10 @@
  */
 package com.google.api.server.spi.testing;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public enum TestEnum {
-  VALUE1, VALUE2
+  VALUE1,
+  @JsonProperty("value_2")
+  VALUE2;
 }


### PR DESCRIPTION
- param and resource de/serialization uses Jackson configuration
- schema generation used Enum.name(), should use Jackson instead