### PR TITLE
Use setHeader for X-Frame-Options in ApiProxyHandler to avoid conflict

### DIFF
--- a/endpoints-framework/src/main/java/com/google/api/server/spi/handlers/ApiProxyHandler.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/handlers/ApiProxyHandler.java
@@ -35,7 +35,7 @@ public class ApiProxyHandler implements DispatcherHandler<EndpointsContext> {
     context.getResponse().setContentType("text/html");
     // This is a nonstandard value, but it seems sometimes X-Frame-Options can be injected by
     // a proxy. We set this explicitly in hopes that the proxy won't override a set value.
-    context.getResponse().addHeader("X-Frame-Options", "ALLOWALL");
+    context.getResponse().setHeader("X-Frame-Options", "ALLOWALL");
     context.getResponse().getWriter().write(cachedProxyHtml);
   }
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aodocs/endpoints-java/21)
<!-- Reviewable:end -->
