### PR TITLE
Switch to altirnao project management

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ version=2.2.1
 
 sourceCompatibility=1.8
 targetCompatibility=1.8
-group=com.google.endpoints
+group=com.altirnao.endpoints
 
 servletVersion=2.5
 javaxinjectVersion=1

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':endpoints-framework', 'endpoints-framework-all', ':endpoints-framework-tools', ':endpoints-framework-guice', ':test-utils', ':discovery-client', ':test-compat', ':test-compat:legacy-app', ':test-compat:new-app', ':test-compat:new-app-guice'
+include ':endpoints-framework', 'endpoints-framework-all', ':endpoints-framework-tools', ':endpoints-framework-guice', ':test-utils', ':discovery-client'


### PR DESCRIPTION
- change groupId of the artifacts
- ignore test-compat during build: the tests fails because
  the switch to the new gradle plugin is required
  (com.google.cloud.tools:appengine-gradle-plugin)
  but this change is complex