### PR TITLE
Remove the root query param from the API explorer URL

### DIFF
--- a/endpoints-framework/src/main/java/com/google/api/server/spi/handlers/ExplorerHandler.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/handlers/ExplorerHandler.java
@@ -38,12 +38,9 @@ public class ExplorerHandler implements DispatcherHandler<EndpointsContext> {
   private String getExplorerUrl(HttpServletRequest req, String path) {
     String url = stripRedundantPorts(Strings.stripTrailingSlash(req.getRequestURL().toString()));
     // This will convert http://localhost:8080/_ah/api/explorer to
-    // ${EXPLORER_URL}?base=http://localhost:8080/_ah/api&root=http://localhost:8080/_ah/api
-    // The root parameter is necessary for the non-default module case and the case where the
-    // host is manually specified. This will override the root, which API explorer now respects
-    // by default.
+    // ${EXPLORER_URL}?base=http://localhost:8080/_ah/api
     String apiRoot = url.substring(0, url.length() - path.length() - 1);
-    return EXPLORER_URL + "?base=" + apiRoot + "&root=" + apiRoot;
+    return EXPLORER_URL + "?base=" + apiRoot;
   }
 
   private static String stripRedundantPorts(String url) {

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/EndpointsServletTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/EndpointsServletTest.java
@@ -75,7 +75,7 @@ public class EndpointsServletTest {
 
     assertThat(resp.getStatus()).isEqualTo(HttpServletResponse.SC_FOUND);
     assertThat(resp.getHeader("Location")).isEqualTo(
-        "https://developers.google.com/apis-explorer/?base=" + API_ROOT + "&root=" + API_ROOT);
+        "https://developers.google.com/apis-explorer/?base=" + API_ROOT);
   }
 
   @Test

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/handlers/ExplorerHandlerTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/handlers/ExplorerHandlerTest.java
@@ -32,19 +32,19 @@ public class ExplorerHandlerTest {
   @Test
   public void testHandle() throws Exception {
     testHandle("http", 8080, "https://developers.google.com/apis-explorer/"
-        + "?base=http://localhost:8080/_ah/api&root=http://localhost:8080/_ah/api");
+        + "?base=http://localhost:8080/_ah/api");
   }
 
   @Test
   public void testHandle_explicitHttpPort() throws Exception {
     testHandle("http", 80, "https://developers.google.com/apis-explorer/"
-        + "?base=http://localhost/_ah/api&root=http://localhost/_ah/api");
+        + "?base=http://localhost/_ah/api");
   }
 
   @Test
   public void testHandle_explicitHttpsPort() throws Exception {
     testHandle("https", 443, "https://developers.google.com/apis-explorer/"
-        + "?base=https://localhost/_ah/api&root=https://localhost/_ah/api");
+        + "?base=https://localhost/_ah/api");
   }
 
   private void testHandle(String scheme, int port, String expectedLocation) throws Exception {


### PR DESCRIPTION
- developers.google.com redirects to appspot if root param is present
- the root param is actually not necessary, so we just remove it