### PR TITLE
Improve generated Swagger spec, especially on names and descriptions

### DIFF
--- a/endpoints-framework-tools/src/main/java/com/google/api/server/spi/tools/GetOpenApiDocAction.java
+++ b/endpoints-framework-tools/src/main/java/com/google/api/server/spi/tools/GetOpenApiDocAction.java
@@ -55,6 +55,7 @@ public class GetOpenApiDocAction extends EndpointsToolAction {
   private Option basePathOption = makeBasePathOption();
   private Option titleOption = makeTitleOption();
   private Option descriptionOption = makeDescriptionOption();
+  private Option apiNameOption = makeApiNameOption();
   private Option addGoogleJsonErrorAsDefaultResponseOption = makeVisibleFlagOption(
       "addGoogleJsonErrorAsDefaultResponse", "Add GoogleJsonError as default response"
   );
@@ -76,7 +77,7 @@ public class GetOpenApiDocAction extends EndpointsToolAction {
     super(alias);
     setOptions(
         Arrays.asList(classPathOption, outputOption, warOption, hostnameOption, basePathOption,
-            titleOption, descriptionOption, 
+            titleOption, descriptionOption, apiNameOption,
             addGoogleJsonErrorAsDefaultResponseOption, addErrorCodesForServiceExceptionsOption,
             extractCommonParametersAsRefsOption, combineCommonParametersInSamePathOption));
     setShortDescription("Generates an OpenAPI document");
@@ -100,6 +101,14 @@ public class GetOpenApiDocAction extends EndpointsToolAction {
         "DESCRIPTION",
         "Sets the description for the generated document. Is empty by default.");
   }
+
+  private static Option makeApiNameOption() {
+    return EndpointsOption.makeVisibleNonFlagOption(
+        "a",
+        "apiName",
+        "API_NAME",
+        "Sets the api name. Endpoints Management will use hostname if not defined.");
+  }
   
   private static boolean getBooleanOptionValue(Option option) {
     return option.getValue() != null;
@@ -122,6 +131,7 @@ public class GetOpenApiDocAction extends EndpointsToolAction {
         getBasePath(basePathOption), 
         getOptionOrDefault(titleOption, null),
         getOptionOrDefault(descriptionOption, null),
+        getOptionOrDefault(apiNameOption, null),
         getBooleanOptionValue(addGoogleJsonErrorAsDefaultResponseOption),
         getBooleanOptionValue(addErrorCodesForServiceExceptionsOption),
         getBooleanOptionValue(extractCommonParametersAsRefsOption),
@@ -143,7 +153,7 @@ public class GetOpenApiDocAction extends EndpointsToolAction {
    */
   public String genOpenApiDoc(
       URL[] classPath, String outputFilePath, String hostname, String basePath,
-      String title, String description,
+      String title, String description, String apiName,
       boolean addGoogleJsonErrorAsDefaultResponse, boolean addErrorCodesForServiceExceptionsOption,
       boolean extractCommonParametersAsRefsOption, boolean combineCommonParametersInSamePathOption,
       List<String> serviceClassNames, boolean outputToDisk)
@@ -171,6 +181,7 @@ public class GetOpenApiDocAction extends EndpointsToolAction {
         .setBasePath(basePath)
         .setTitle(title)
         .setDescription(description)
+        .setApiName(apiName)
         .setAddErrorCodesForServiceExceptions(addGoogleJsonErrorAsDefaultResponse)
         .setAddErrorCodesForServiceExceptions(addErrorCodesForServiceExceptionsOption)
         .setExtractCommonParametersAsRefs(extractCommonParametersAsRefsOption)

--- a/endpoints-framework-tools/src/main/java/com/google/api/server/spi/tools/GetOpenApiDocAction.java
+++ b/endpoints-framework-tools/src/main/java/com/google/api/server/spi/tools/GetOpenApiDocAction.java
@@ -182,7 +182,7 @@ public class GetOpenApiDocAction extends EndpointsToolAction {
         .setTitle(title)
         .setDescription(description)
         .setApiName(apiName)
-        .setAddErrorCodesForServiceExceptions(addGoogleJsonErrorAsDefaultResponse)
+        .setAddGoogleJsonErrorAsDefaultResponse(addGoogleJsonErrorAsDefaultResponse)
         .setAddErrorCodesForServiceExceptions(addErrorCodesForServiceExceptionsOption)
         .setExtractCommonParametersAsRefs(extractCommonParametersAsRefsOption)
         .setCombineCommonParametersInSamePath(combineCommonParametersInSamePathOption);

--- a/endpoints-framework-tools/src/test/java/com/google/api/server/spi/tools/GetOpenApiDocActionTest.java
+++ b/endpoints-framework-tools/src/test/java/com/google/api/server/spi/tools/GetOpenApiDocActionTest.java
@@ -55,7 +55,7 @@ public class GetOpenApiDocActionTest extends EndpointsToolTest {
       @Override
       public String genOpenApiDoc(
           URL[] classPath, String outputFilePath, String hostname, String basePath,
-          String title, String description,
+          String title, String description, String apiName,
           boolean addGoogleJsonErrorAsDefaultResponse,
           boolean addErrorCodesForServiceExceptionsOption,
           boolean extractCommonParametersAsRefsOption,

--- a/endpoints-framework/build.gradle
+++ b/endpoints-framework/build.gradle
@@ -116,5 +116,9 @@ dependencies {
   testCompile group: 'com.google.appengine', name: 'appengine-api-stubs', version: appengineVersion
   testCompile group: 'org.springframework', name: 'spring-test', version: springtestVersion
   testCompile group: 'com.google.guava', name: 'guava-testlib', version: guavaVersion
+  testCompile (group: 'io.swagger', name: 'swagger-validator', version: '1.0.6') {
+    exclude group: 'javax.servlet', module: 'javax.servlet-api'
+    exclude group: 'ch.qos.logback', module: 'logback-classic'
+  }
 }
 

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/Description.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/Description.java
@@ -21,14 +21,17 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation to specify the description of an API parameter or enum constants.
+ * Annotation to specify the description of a method parameter, enum type, enum constant or
+ * resource (type used as request body).
+ * If used on an enum type, the description will only be used for the Discovery format (OpenAPI
+ * will inline enum values, as the semantics is poorer).
  * The description will be ignored if the annotation is used on resource fields.
  */
-@Target({ElementType.PARAMETER, ElementType.FIELD})
+@Target({ElementType.PARAMETER, ElementType.FIELD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Description {
   /**
-   * The parameter description.
+   * A description.
    */
   String value() default "";
 }

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/annotationreader/ApiAnnotationIntrospector.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/annotationreader/ApiAnnotationIntrospector.java
@@ -58,10 +58,6 @@ public class ApiAnnotationIntrospector extends NopAnnotationIntrospector {
 
   private final ApiSerializationConfig config;
 
-  public ApiAnnotationIntrospector() {
-    this(new ApiSerializationConfig());
-  }
-
   public ApiAnnotationIntrospector(ApiSerializationConfig config) {
     this.config = config;
   }
@@ -101,11 +97,6 @@ public class ApiAnnotationIntrospector extends NopAnnotationIntrospector {
   @Override
   public JsonSerializer<?> findSerializer(Annotated method) {
     return getJsonSerializer(findSerializerInstance(method));
-  }
-
-  @Override
-  public String findEnumValue(Enum<?> value) {
-    return value.name();
   }
 
   @Nullable

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/jsonwriter/AbstractResourceSchemaProvider.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/jsonwriter/AbstractResourceSchemaProvider.java
@@ -40,7 +40,6 @@ abstract class AbstractResourceSchemaProvider implements ResourceSchemaProvider 
 
   @Nullable
   private <T> ResourceSchema getResourceSchemaImpl(TypeToken<T> type, ApiConfig config) {
-    Class<? super T> clazz = type.getRawType();
     List<Class<? extends Transformer<?, ?>>> serializerClasses =
         Serializers.getSerializerClasses(type, config.getSerializationConfig());
     if (!serializerClasses.isEmpty() &&

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/SwaggerGenerator.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/SwaggerGenerator.java
@@ -267,7 +267,7 @@ public class SwaggerGenerator {
   }
 
   /*
-   * Swagger library will set parameters to empty by default. We force them to be empty.
+   * Swagger library will set parameters to empty by default. We force them to be null.
    * If not empty, makes sure the body is always last.
    */
   public static void normalizeOperationParameters(Swagger swagger) {

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/SwaggerGenerator.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/SwaggerGenerator.java
@@ -446,8 +446,10 @@ public class SwaggerGenerator {
               && defaultValue == null);
           if (parameterConfig.isRepeated()) {
             TypeToken<?> t = parameterConfig.getRepeatedItemSerializedType();
-            parameter.setType("array");
-            parameter.setCollectionFormat("multi");
+            parameter.type("array")
+                //RestServletRequestParamReader uses "," as a separator for repeated path params 
+                // => csv, but reads multiple occurrences of query parameters => multi
+                .collectionFormat(isPathParameter ? "csv" : "multi");
             Property p = getSwaggerArrayProperty(t);
             if (parameterConfig.isEnum()) {  // TODO: Not sure if this is the right check
               ((StringProperty) p).setEnum(getEnumValues(t));

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/SwaggerGenerator.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/SwaggerGenerator.java
@@ -52,6 +52,7 @@ import com.google.common.collect.HashMultiset;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap.Builder;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
@@ -371,20 +372,19 @@ public class SwaggerGenerator {
       List<Map<String, Object>> limits = new ArrayList<>();
       List<Map<String, Object>> metrics = new ArrayList<>();
       for (ApiLimitMetricConfig limitMetric : genCtx.limitMetrics.values()) {
-        metrics.add(ImmutableMap.<String, Object>builder()
+        Builder<String, Object> builder = ImmutableMap.<String, Object>builder()
             .put(METRIC_NAME_KEY, limitMetric.name())
             .put(METRIC_VALUE_TYPE_KEY, METRIC_VALUE_TYPE)
-            .put(METRIC_KIND_KEY, METRIC_KIND)
-            .build());
-        ImmutableMap.Builder<String, Object> limitBuilder = ImmutableMap.<String, Object>builder()
+            .put(METRIC_KIND_KEY, METRIC_KIND);
+        if (limitMetric.displayName() != null && !"".equals(limitMetric.displayName())) {
+          builder.put(LIMIT_DISPLAY_NAME_KEY, limitMetric.displayName());
+        }
+        metrics.add(builder.build());
+        limits.add(ImmutableMap.<String, Object>builder()
             .put(LIMIT_NAME_KEY, limitMetric.name())
             .put(LIMIT_METRIC_KEY, limitMetric.name())
             .put(LIMIT_DEFAULT_LIMIT_KEY, ImmutableMap.of("STANDARD", limitMetric.limit()))
-            .put(LIMIT_UNIT_KEY, LIMIT_PER_MINUTE_PER_PROJECT);
-        if (limitMetric.displayName() != null && !"".equals(limitMetric.displayName())) {
-          limitBuilder.put(LIMIT_DISPLAY_NAME_KEY, limitMetric.displayName());
-        }
-        limits.add(limitBuilder.build());
+            .put(LIMIT_UNIT_KEY, LIMIT_PER_MINUTE_PER_PROJECT).build());
       }
       quotaDefinitions.put(LIMITS_KEY, limits);
       swagger.setVendorExtension(MANAGEMENT_DEFINITIONS_KEY,

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/SwaggerGenerator.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/SwaggerGenerator.java
@@ -246,8 +246,24 @@ public class SwaggerGenerator {
     }
     swagger.paths(builder.build());
     combineCommonParameters(swagger, context);
+    normalizeOperationParameters(swagger);
     writeQuotaDefinitions(swagger, genCtx);
     return swagger;
+  }
+
+  /*
+   * Swagger library will set parameters to empty by default. We force them to be empty.
+   * If not empty, makes sure the body is always last.
+   */
+  public static void normalizeOperationParameters(Swagger swagger) {
+    swagger.getPaths().values().stream()
+        .flatMap(path -> path.getOperations().stream())
+        .forEach(operation -> {
+          List<Parameter> parameters = operation.getParameters();
+          if (parameters != null && parameters.isEmpty()) {
+            operation.setParameters(null);
+          }
+        });
   }
 
   private void combineCommonParameters(Swagger swagger, SwaggerContext context) {

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/SwaggerGenerator.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/SwaggerGenerator.java
@@ -233,6 +233,9 @@ public class SwaggerGenerator {
             .version(context.docVersion)
             //TODO contact, license, termsOfService could be configured
         );
+    if (!Strings.isEmptyOrWhitespace(context.apiName)) {
+      swagger.vendorExtension("x-google-api-name", context.apiName);
+    }
     for (ApiKey apiKey : configsByKey.keySet()) {
       writeApi(apiKey, configsByKey.get(apiKey), swagger, context, genCtx);
     }
@@ -376,7 +379,7 @@ public class SwaggerGenerator {
             .put(METRIC_NAME_KEY, limitMetric.name())
             .put(METRIC_VALUE_TYPE_KEY, METRIC_VALUE_TYPE)
             .put(METRIC_KIND_KEY, METRIC_KIND);
-        if (limitMetric.displayName() != null && !"".equals(limitMetric.displayName())) {
+        if (!Strings.isEmptyOrWhitespace(limitMetric.displayName())) {
           builder.put(LIMIT_DISPLAY_NAME_KEY, limitMetric.displayName());
         }
         metrics.add(builder.build());
@@ -860,32 +863,17 @@ public class SwaggerGenerator {
     private String docVersion = "1.0.0";
     private String title;
     private String description;
+    private String apiName;
     private boolean addGoogleJsonErrorAsDefaultResponse;
     private boolean addErrorCodesForServiceExceptions;
     private boolean extractCommonParametersAsRefs;
     private boolean combineCommonParametersInSamePath;
 
-    public SwaggerContext setApiRoot(String apiRoot) {
-      try {
-        URL url = new URL(apiRoot);
-        hostname = url.getHost();
-        if (("http".equals(url.getProtocol()) && url.getPort() != 80 && url.getPort() != -1)
-            || ("https".equals(url.getProtocol()) && url.getPort() != 443 && url.getPort() != -1)) {
-          hostname += ":" + url.getPort();
-        }
-        basePath = Strings.stripTrailingSlash(url.getPath());
-        setScheme(url.getProtocol());
-        return this;
-      } catch (MalformedURLException e) {
-        throw new IllegalArgumentException(e);
-      }
-    }
-
     public SwaggerContext setScheme(String scheme) {
       this.scheme = "http".equals(scheme) ? Scheme.HTTP : Scheme.HTTPS;
       return this;
     }
-
+    
     public SwaggerContext setHostname(String hostname) {
       this.hostname = hostname;
       return this;
@@ -908,6 +896,11 @@ public class SwaggerGenerator {
 
     public SwaggerContext setDescription(String description) {
       this.description = description;
+      return this;
+    }
+
+    public SwaggerContext setApiName(String apiName) {
+      this.apiName = apiName;
       return this;
     }
 

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/SwaggerGenerator.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/SwaggerGenerator.java
@@ -531,7 +531,8 @@ public class SwaggerGenerator {
       TypeToken<?> returnType =
           ApiAnnotationIntrospector.getSchemaType(methodConfig.getReturnType(), apiConfig);
       Schema schema = genCtx.schemata.getOrAdd(returnType, apiConfig);
-      response.responseSchema(getSchema(schema));
+      response.responseSchema(getSchema(schema))
+        .description("A " + schema.name() + " response");
     }
     operation.response(responseCode, response);
 

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/SwaggerGenerator.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/SwaggerGenerator.java
@@ -469,9 +469,11 @@ public class SwaggerGenerator {
         case RESOURCE:
           TypeToken<?> requestType = parameterConfig.getSchemaBaseType();
           Schema schema = genCtx.schemata.getOrAdd(requestType, apiConfig);
-          BodyParameter bodyParameter = new BodyParameter();
-          bodyParameter.setName("body");
-          bodyParameter.setSchema(getSchema(schema));
+          BodyParameter bodyParameter = new BodyParameter()
+              .name(schema.name())
+              .description(parameterConfig.getDescription())
+              .schema(getSchema(schema));
+          bodyParameter.setRequired(true);
           operation.addParameter(bodyParameter);
           break;
         case UNKNOWN:
@@ -608,7 +610,10 @@ public class SwaggerGenerator {
 
   private Model convertToSwaggerSchema(Schema schema) {
     ModelImpl docSchema = new ModelImpl().type("object");
-    Map<String, Property> fields = new TreeMap<>();
+    String description = schema.description();
+    if (!Strings.isEmptyOrWhitespace(description)) {
+      docSchema.description(description);
+    }
     if (!schema.fields().isEmpty()) {
       for (Field f : schema.fields().values()) {
         fields.put(f.name(), convertToSwaggerProperty(f));

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/config/model/SchemaRepositoryTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/config/model/SchemaRepositoryTest.java
@@ -97,6 +97,7 @@ public class SchemaRepositoryTest {
     Schema schema = repo.getOrAdd(methodConfig.getReturnType(), config);
     assertThat(schema).isEqualTo(Schema.builder()
         .setName("Map_String_TestEnum")
+        .setDescription("A collection of name / TestEnum pairs")
         .setType("object")
         .setMapValueSchema(Field.builder()
             .setName(SchemaRepository.MAP_UNUSED_MSG)
@@ -138,6 +139,7 @@ public class SchemaRepositoryTest {
     Schema expectedSchema = Schema.builder()
         .setName("Map_String_Map_String_String")
         .setType("object")
+        .setDescription("A collection of name / Map_String_String pairs")
         .setMapValueSchema(Field.builder()
             .setName(SchemaRepository.MAP_UNUSED_MSG)
             .setType(FieldType.OBJECT)

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/discovery/DiscoveryGeneratorTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/discovery/DiscoveryGeneratorTest.java
@@ -296,8 +296,6 @@ public class DiscoveryGeneratorTest {
   }
 
   private void compareDiscovery(RestDescription expected, RestDescription actual) throws Exception {
-    System.out.println("Actual: " + mapper.writeValueAsString(actual));
-    System.out.println("Expected: " + mapper.writeValueAsString(expected));
-    assertThat(actual).isEqualTo(expected);
+    DiscoverySubject.assertThat(actual).isSameAs(expected);
   }
 }

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/discovery/DiscoverySubject.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/discovery/DiscoverySubject.java
@@ -15,7 +15,7 @@ import org.junit.ComparisonFailure;
 
 public final class DiscoverySubject extends Subject {
 
-  private final ObjectWriter witer = Json.mapper().writerWithDefaultPrettyPrinter();
+  private final ObjectWriter writer = Json.mapper().writerWithDefaultPrettyPrinter();
 
   private final RestDescription actual;
 
@@ -45,7 +45,7 @@ public final class DiscoverySubject extends Subject {
 
   private String toString(RestDescription expected) {
     try {
-      return witer.writeValueAsString(expected);
+      return writer.writeValueAsString(expected);
     } catch (JsonProcessingException e) {
       throw new AssertionError("Cannot create String representation for specs", e);
     }

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/discovery/DiscoverySubject.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/discovery/DiscoverySubject.java
@@ -1,0 +1,54 @@
+package com.google.api.server.spi.discovery;
+
+import static com.google.common.truth.Truth.assertAbout;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.google.api.services.discovery.model.RestDescription;
+import com.google.common.truth.FailureMetadata;
+import com.google.common.truth.Subject;
+import io.swagger.util.Json;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
+import org.junit.ComparisonFailure;
+
+public final class DiscoverySubject extends Subject {
+
+  private final ObjectWriter witer = Json.mapper().writerWithDefaultPrettyPrinter();
+
+  private final RestDescription actual;
+
+  public static DiscoverySubject assertThat(@NullableDecl RestDescription swagger) {
+    return assertAbout(discoveries()).that(swagger);
+  }
+
+  private static Factory<DiscoverySubject, RestDescription> discoveries() {
+    return DiscoverySubject::new;
+  }
+
+  private DiscoverySubject(FailureMetadata failureStrategy, @Nullable Object actual) {
+    super(failureStrategy, actual);
+    this.actual = actual instanceof RestDescription ? (RestDescription) actual : null;
+  }
+
+  void isSameAs(RestDescription expected) {
+    checkEquality(expected);
+  }
+
+  private void checkEquality(RestDescription expected) {
+    if (!Objects.equals(actual, expected)) {
+      throw new ComparisonFailure("Discovery specs don't match",
+          toString(expected), toString(actual));
+    }
+  }
+
+  private String toString(RestDescription expected) {
+    try {
+      return witer.writeValueAsString(expected);
+    } catch (JsonProcessingException e) {
+      throw new AssertionError("Cannot create String representation for specs", e);
+    }
+  }
+
+}

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/swagger/SwaggerGeneratorTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/swagger/SwaggerGeneratorTest.java
@@ -75,7 +75,9 @@ import io.swagger.util.Json;
 public class SwaggerGeneratorTest {
   private final SwaggerGenerator generator = new SwaggerGenerator();
   private final SwaggerContext context = new SwaggerContext()
-      .setApiRoot("https://swagger-test.appspot.com/api");
+      .setScheme("https")
+      .setHostname("swagger-test.appspot.com")
+      .setBasePath("/api");
   private final ObjectMapper mapper = Json.mapper();
   private ApiConfigLoader configLoader;
 
@@ -136,10 +138,10 @@ public class SwaggerGeneratorTest {
   }
 
   @Test
-  public void testWriteSwagger_FooEndpointLocalhost() throws Exception {
+  public void testWriteSwagger_FooEndpointWithApiName() throws Exception {
     Swagger swagger = getSwagger(
-        FooEndpoint.class, new SwaggerContext().setApiRoot("http://localhost:8080/api"));
-    Swagger expected = readExpectedAsSwagger("foo_endpoint_localhost.swagger");
+        FooEndpoint.class, new SwaggerContext().setApiName("customApiName"));
+    Swagger expected = readExpectedAsSwagger("foo_endpoint_api_name.swagger");
     checkSwagger(expected, swagger);
   }
 

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/swagger/SwaggerGeneratorTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/swagger/SwaggerGeneratorTest.java
@@ -54,6 +54,7 @@ import com.google.api.server.spi.testing.MultiResourceEndpoint.Resource1Endpoint
 import com.google.api.server.spi.testing.MultiResourceEndpoint.Resource2Endpoint;
 import com.google.api.server.spi.testing.MultiVersionEndpoint.Version1Endpoint;
 import com.google.api.server.spi.testing.MultiVersionEndpoint.Version2Endpoint;
+import com.google.api.server.spi.testing.SpecialCharsEndpoint;
 import com.google.common.collect.ImmutableList;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -334,6 +335,15 @@ public class SwaggerGeneratorTest {
     }
   }
 
+  @Test
+  public void testWriteSwagger_SpecialChars() throws Exception {
+    ApiConfig config = configLoader.loadConfiguration(ServiceContext.create(), SpecialCharsEndpoint.class);
+    Swagger swagger = generator.writeSwagger(ImmutableList.of(config), context
+        .setExtractCommonParametersAsRefs(true));
+    Swagger expected = readExpectedAsSwagger("special_chars.swagger");
+    checkSwagger(expected, swagger);
+  }
+
   private Swagger getSwagger(Class<?> serviceClass, SwaggerContext context)
       throws Exception {
     ApiConfig config = configLoader.loadConfiguration(ServiceContext.create(), serviceClass);
@@ -345,7 +355,7 @@ public class SwaggerGeneratorTest {
     return mapper.readValue(expectedString, Swagger.class);
   }
 
-  private void checkSwagger(Swagger expected, Swagger actual) throws Exception {
+  private void checkSwagger(Swagger expected, Swagger actual) {
     SwaggerSubject.assertThat(actual).isValid();
     SwaggerSubject.assertThat(actual).isSameAs(expected);
   }

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/swagger/SwaggerGeneratorTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/swagger/SwaggerGeneratorTest.java
@@ -332,8 +332,8 @@ public class SwaggerGeneratorTest {
   }
 
   private void checkSwagger(Swagger expected, Swagger actual) throws Exception {
+    SwaggerSubject.assertThat(actual).isValid();
     SwaggerSubject.assertThat(actual).isSameAs(expected);
-    SwaggerSubject.assertThat(actual).hasNoDuplicateOperations();
   }
 
   @Api(name = "thirdparty", version = "v1",

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/swagger/SwaggerSubject.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/swagger/SwaggerSubject.java
@@ -59,12 +59,14 @@ public final class SwaggerSubject extends Subject {
 
   private void validatesSchema() {
     //TODO there is probably a better way to validate, to get errors like https://editor.swagger.io/
+    // This validator will only validate against the JsonSchema, not check references for example 
     try {
       ValidationResponse validationResponse = new ValidatorService()
           .debugByContent(null, null, toString(actual));
       List<SchemaValidationError> schemaValidationMessages = validationResponse
           .getSchemaValidationMessages();
       if (schemaValidationMessages != null && !schemaValidationMessages.isEmpty()) {
+        System.out.println("Swagger spec: " + toString(actual));
         throw new AssertionError("Swagger spec is not valid" +
             schemaValidationMessages.stream()
                 .map(error -> "\nValidation error: " + toString(error))

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/swagger/SwaggerSubject.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/swagger/SwaggerSubject.java
@@ -16,6 +16,11 @@ import io.swagger.models.Operation;
 import io.swagger.models.Path;
 import io.swagger.models.Swagger;
 import io.swagger.util.Json;
+import io.swagger.validator.models.SchemaValidationError;
+import io.swagger.validator.models.ValidationResponse;
+import io.swagger.validator.services.ValidatorService;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 import org.junit.ComparisonFailure;
 
@@ -47,7 +52,30 @@ public final class SwaggerSubject extends Subject {
     this.actual = actual instanceof Swagger ? (Swagger) actual : null;
   }
 
-  void hasNoDuplicateOperations() {
+  void isValid() {
+    validatesSchema();
+    hasNoDuplicateOperations();
+  }
+
+  private void validatesSchema() {
+    //TODO there is probably a better way to validate, to get errors like https://editor.swagger.io/
+    try {
+      ValidationResponse validationResponse = new ValidatorService()
+          .debugByContent(null, null, toString(actual));
+      List<SchemaValidationError> schemaValidationMessages = validationResponse
+          .getSchemaValidationMessages();
+      if (schemaValidationMessages != null && !schemaValidationMessages.isEmpty()) {
+        throw new AssertionError("Swagger spec is not valid" +
+            schemaValidationMessages.stream()
+                .map(error -> "\nValidation error: " + toString(error))
+                .collect(Collectors.joining()));
+      }
+    } catch (Exception e) {
+      throw new AssertionError("Could not validate Swagger spec", e);
+    }
+  }
+
+  private void hasNoDuplicateOperations() {
     Multimap<String, String> operationIds = HashMultimap.create();
     for (Entry<String, Path> pathEntry : actual.getPaths().entrySet()) {
       for (Entry<HttpMethod, Operation> opEntry : pathEntry.getValue().getOperationMap()
@@ -75,9 +103,12 @@ public final class SwaggerSubject extends Subject {
     compareMapOrdering("Security definition", actual, expected, Swagger::getSecurityDefinitions);
     compareMapOrdering("Model definition", actual, expected, Swagger::getDefinitions);
     compareMapOrdering("Path", actual, expected, Swagger::getPaths);
+    compareMapOrdering("Parameter", actual, expected, Swagger::getParameters);
+    compareMapOrdering("Response", actual, expected, Swagger::getResponses);
   }
 
   private void checkEquality(Swagger expected) {
+    SwaggerGenerator.normalizeOperationParameters(expected);
     if (!Objects.equals(actual, expected)) {
       throw new ComparisonFailure("Swagger specs don't match",
           toString(expected), toString(actual));
@@ -100,11 +131,11 @@ public final class SwaggerSubject extends Subject {
     }
   }
 
-  private String toString(Swagger expected) {
+  private String toString(Object toJson) {
     try {
-      return witer.writeValueAsString(expected);
+      return witer.writeValueAsString(toJson);
     } catch (JsonProcessingException e) {
-      throw new AssertionError("Cannot create String representation for specs", e);
+      throw new AssertionError("Cannot create String representation", e);
     }
   }
 

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/discovery/array_endpoint.json
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/discovery/array_endpoint.json
@@ -423,6 +423,25 @@
           "scopes": [
             "https://www.googleapis.com/auth/userinfo.email"
           ]
+        },
+        "setListOfStringAsQueryParam": {
+          "httpMethod": "POST",
+          "id": "myapi.arrayEndpoint.setListOfStringAsQueryParam",
+          "parameterOrder": [
+            "list"
+          ],
+          "parameters": {
+            "list": {
+              "location": "query",
+              "repeated": true,
+              "required": true,
+              "type": "string"
+            }
+          },
+          "path": "setListOfStringAsQueryParam",
+          "scopes": [
+            "https://www.googleapis.com/auth/userinfo.email"
+          ]
         }
       }
     }
@@ -495,6 +514,12 @@
         },
         "listOfString": {
           "$ref": "ListContainer"
+        },
+        "listOfStringAsQueryParam": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         },
         "objectIntegers": {
           "items": {
@@ -605,6 +630,7 @@
       "type": "object"
     },
     "FooCollection": {
+      "description": "An ordered list of Foo",
       "id": "FooCollection",
       "properties": {
         "items": {

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/discovery/foo_with_description_endpoint.json
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/discovery/foo_with_description_endpoint.json
@@ -239,6 +239,7 @@
       "type": "object"
     },
     "FooDescription": {
+      "description": "Description at class level",
       "id": "FooDescription",
       "properties": {
         "choice": {
@@ -246,11 +247,11 @@
           "description": "description of choice"
         },
         "name": {
-          "description":"description of name",
+          "description": "description of name",
           "type": "string"
         },
         "value": {
-          "description":"description of value",
+          "description": "description of value",
           "format": "int32",
           "type": "integer"
         }
@@ -258,6 +259,7 @@
       "type": "object"
     },
     "TestEnumDescription": {
+      "description": "A list of enum values",
       "enum": [
         "VALUE1",
         "VALUE2"
@@ -267,7 +269,7 @@
         "description of value2"
       ],
       "id": "TestEnumDescription",
-      "type":"string"
+      "type": "string"
     }
   },
   "servicePath": "foo/v1/",

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/discovery/map_endpoint.json
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/discovery/map_endpoint.json
@@ -421,6 +421,7 @@
       "additionalProperties": {
         "$ref": "Baz"
       },
+      "description": "A collection of name / Baz pairs",
       "id": "Map_String_Baz",
       "type": "object"
     },
@@ -428,6 +429,7 @@
       "additionalProperties": {
         "$ref": "Foo"
       },
+      "description": "A collection of name / Foo pairs",
       "id": "Map_String_Foo",
       "type": "object"
     },
@@ -443,6 +445,7 @@
       "additionalProperties": {
         "$ref": "Map_String_Foo"
       },
+      "description": "A collection of name / Map_String_Foo pairs",
       "id": "Map_String_Map_String_Foo",
       "type": "object"
     },

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/discovery/map_endpoint_with_array.json
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/discovery/map_endpoint_with_array.json
@@ -417,6 +417,7 @@
       "additionalProperties": {
         "$ref": "Baz"
       },
+      "description": "A collection of name / Baz pairs",
       "id": "Map_String_Baz",
       "type": "object"
     },
@@ -424,6 +425,7 @@
       "additionalProperties": {
         "$ref": "Foo"
       },
+      "description": "A collection of name / Foo pairs",
       "id": "Map_String_Foo",
       "type": "object"
     },
@@ -439,6 +441,7 @@
       "additionalProperties": {
         "$ref": "Map_String_Foo"
       },
+      "description": "A collection of name / Map_String_Foo pairs",
       "id": "Map_String_Map_String_Foo",
       "type": "object"
     },

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/discovery/primitive_endpoint.json
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/discovery/primitive_endpoint.json
@@ -134,6 +134,7 @@
       "type": "object"
     },
     "PrimitiveBeanCollection": {
+      "description": "An ordered list of PrimitiveBean",
       "id": "PrimitiveBeanCollection",
       "properties": {
         "items": {

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/absolute_common_path_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/absolute_common_path_endpoint.swagger
@@ -27,7 +27,6 @@
           "absolutepath:v1"
         ],
         "operationId": "AbsolutepathV1AbsolutePath",
-        "parameters": [],
         "responses": {
           "204": {
             "description": "A successful response"
@@ -41,7 +40,6 @@
           "absolutepath:v1"
         ],
         "operationId": "AbsolutepathV1CreateFoo",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/absolute_common_path_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/absolute_common_path_endpoint.swagger
@@ -42,7 +42,7 @@
         "operationId": "AbsolutepathV1CreateFoo",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Foo response",
             "schema": {
               "$ref": "#/definitions/Foo"
             }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/absolute_path_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/absolute_path_endpoint.swagger
@@ -29,7 +29,7 @@
         "operationId": "AbsolutepathV1CreateFoo",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Foo response",
             "schema": {
               "$ref": "#/definitions/Foo"
             }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/absolute_path_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/absolute_path_endpoint.swagger
@@ -27,7 +27,6 @@
           "absolutepath:v1"
         ],
         "operationId": "AbsolutepathV1CreateFoo",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -44,7 +43,6 @@
           "absolutepath:v1"
         ],
         "operationId": "AbsolutepathV1AbsolutePath",
-        "parameters": [],
         "responses": {
           "204": {
             "description": "A successful response"
@@ -58,7 +56,6 @@
           "absolutepath:v1"
         ],
         "operationId": "AbsolutepathV1AbsolutePath2",
-        "parameters": [],
         "responses": {
           "204": {
             "description": "A successful response"

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/api_keys.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/api_keys.swagger
@@ -27,7 +27,6 @@
           "apikeys:v1"
         ],
         "operationId": "ApikeysV1ApiKeyWithAuth",
-        "parameters": [],
         "responses": {
           "204": {
             "description": "A successful response"
@@ -47,7 +46,6 @@
           "apikeys:v1"
         ],
         "operationId": "ApikeysV1InheritApiKeySetting",
-        "parameters": [],
         "responses": {
           "204": {
             "description": "A successful response"
@@ -66,7 +64,6 @@
           "apikeys:v1"
         ],
         "operationId": "ApikeysV1OverrideApiKeySetting",
-        "parameters": [],
         "responses": {
           "204": {
             "description": "A successful response"

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/array_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/array_endpoint.swagger
@@ -27,7 +27,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetArrayService",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -44,7 +43,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetBaz",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -61,7 +59,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetFoosResponse",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -78,7 +75,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetFoos",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -95,7 +91,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetAllArrayedFoos",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -112,7 +107,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetAllFoos",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -129,7 +123,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetAllFoosResponse",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -146,7 +139,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetAllNestedFoosResponse",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -163,7 +155,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetArrayedFoos",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -180,7 +171,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetIntegersResponse",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -197,7 +187,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetListOfString",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -214,7 +203,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetObjectIntegers",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -231,7 +219,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetIntegers",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -257,7 +244,7 @@
             "items": {
               "type": "boolean"
             },
-            "collectionFormat": "multi"
+            "collectionFormat": "csv"
           },
           {
             "name": "array",
@@ -267,7 +254,7 @@
             "items": {
               "type": "boolean"
             },
-            "collectionFormat": "multi"
+            "collectionFormat": "csv"
           }
         ],
         "responses": {
@@ -294,7 +281,7 @@
               "format": "byte",
               "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"
             },
-            "collectionFormat": "multi"
+            "collectionFormat": "csv"
           },
           {
             "name": "array",
@@ -306,7 +293,7 @@
               "format": "byte",
               "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"
             },
-            "collectionFormat": "multi"
+            "collectionFormat": "csv"
           }
         ],
         "responses": {
@@ -332,7 +319,7 @@
               "type": "number",
               "format": "double"
             },
-            "collectionFormat": "multi"
+            "collectionFormat": "csv"
           },
           {
             "name": "array",
@@ -343,7 +330,7 @@
               "type": "number",
               "format": "double"
             },
-            "collectionFormat": "multi"
+            "collectionFormat": "csv"
           }
         ],
         "responses": {
@@ -372,7 +359,7 @@
                 "value_2"
               ]
             },
-            "collectionFormat": "multi"
+            "collectionFormat": "csv"
           }
         ],
         "responses": {
@@ -398,7 +385,7 @@
               "type": "number",
               "format": "float"
             },
-            "collectionFormat": "multi"
+            "collectionFormat": "csv"
           },
           {
             "name": "array",
@@ -409,7 +396,7 @@
               "type": "number",
               "format": "float"
             },
-            "collectionFormat": "multi"
+            "collectionFormat": "csv"
           }
         ],
         "responses": {
@@ -435,7 +422,7 @@
               "type": "integer",
               "format": "int32"
             },
-            "collectionFormat": "multi"
+            "collectionFormat": "csv"
           },
           {
             "name": "array",
@@ -446,7 +433,7 @@
               "type": "integer",
               "format": "int32"
             },
-            "collectionFormat": "multi"
+            "collectionFormat": "csv"
           }
         ],
         "responses": {
@@ -472,7 +459,7 @@
               "type": "integer",
               "format": "int64"
             },
-            "collectionFormat": "multi"
+            "collectionFormat": "csv"
           },
           {
             "name": "array",
@@ -483,7 +470,7 @@
               "type": "integer",
               "format": "int64"
             },
-            "collectionFormat": "multi"
+            "collectionFormat": "csv"
           }
         ],
         "responses": {
@@ -504,6 +491,31 @@
             "name": "list",
             "in": "path",
             "required": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "csv"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "A successful response"
+          }
+        }
+      }
+    },
+    "/myapi/v1/setListOfStringAsQueryParam": {
+      "post": {
+        "tags": [
+          "myapi:v1"
+        ],
+        "operationId": "MyapiV1SetListOfStringAsQueryParam",
+        "parameters": [
+          {
+            "name": "list",
+            "in": "query",
+            "required": false,
             "type": "array",
             "items": {
               "type": "string"
@@ -590,6 +602,12 @@
         },
         "listOfString": {
           "$ref": "#/definitions/ListContainer"
+        },
+        "listOfStringAsQueryParam": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "objectIntegers": {
           "type": "array",
@@ -701,7 +719,8 @@
             "$ref": "#/definitions/Foo"
           }
         }
-      }
+      },
+      "description": "An ordered list of Foo"
     },
     "FooCollectionCollection": {
       "type": "object",

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/array_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/array_endpoint.swagger
@@ -29,7 +29,7 @@
         "operationId": "MyapiV1GetArrayService",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A ArrayEndpoint response",
             "schema": {
               "$ref": "#/definitions/ArrayEndpoint"
             }
@@ -45,7 +45,7 @@
         "operationId": "MyapiV1GetBaz",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Baz response",
             "schema": {
               "$ref": "#/definitions/Baz"
             }
@@ -61,7 +61,7 @@
         "operationId": "MyapiV1GetFoosResponse",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A CollectionResponse_Foo response",
             "schema": {
               "$ref": "#/definitions/CollectionResponse_Foo"
             }
@@ -77,7 +77,7 @@
         "operationId": "MyapiV1GetFoos",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A FooCollection response",
             "schema": {
               "$ref": "#/definitions/FooCollection"
             }
@@ -93,7 +93,7 @@
         "operationId": "MyapiV1GetAllArrayedFoos",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A FooCollectionCollection response",
             "schema": {
               "$ref": "#/definitions/FooCollectionCollection"
             }
@@ -109,7 +109,7 @@
         "operationId": "MyapiV1GetAllFoos",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A FooCollectionCollection response",
             "schema": {
               "$ref": "#/definitions/FooCollectionCollection"
             }
@@ -125,7 +125,7 @@
         "operationId": "MyapiV1GetAllFoosResponse",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A CollectionResponse_FooCollection response",
             "schema": {
               "$ref": "#/definitions/CollectionResponse_FooCollection"
             }
@@ -141,7 +141,7 @@
         "operationId": "MyapiV1GetAllNestedFoosResponse",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A CollectionResponse_FooCollectionCollection response",
             "schema": {
               "$ref": "#/definitions/CollectionResponse_FooCollectionCollection"
             }
@@ -157,7 +157,7 @@
         "operationId": "MyapiV1GetArrayedFoos",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A FooCollection response",
             "schema": {
               "$ref": "#/definitions/FooCollection"
             }
@@ -173,7 +173,7 @@
         "operationId": "MyapiV1GetIntegersResponse",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A CollectionResponse_Integer response",
             "schema": {
               "$ref": "#/definitions/CollectionResponse_Integer"
             }
@@ -189,7 +189,7 @@
         "operationId": "MyapiV1GetListOfString",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A ListContainer response",
             "schema": {
               "$ref": "#/definitions/ListContainer"
             }
@@ -205,7 +205,7 @@
         "operationId": "MyapiV1GetObjectIntegers",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A IntegerCollection response",
             "schema": {
               "$ref": "#/definitions/IntegerCollection"
             }
@@ -221,7 +221,7 @@
         "operationId": "MyapiV1GetIntegers",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A IntegerCollection response",
             "schema": {
               "$ref": "#/definitions/IntegerCollection"
             }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/enum_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/enum_endpoint.swagger
@@ -41,7 +41,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A EnumValue response",
             "schema": {
               "$ref": "#/definitions/EnumValue"
             }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/error_codes_all.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/error_codes_all.swagger
@@ -27,16 +27,12 @@
           "exceptions:v1"
         ],
         "operationId": "ExceptionsV1DoesNotThrow",
-        "parameters": [],
         "responses": {
           "204": {
             "description": "A successful response"
           },
           "default": {
-            "description": "A failed response",
-            "schema": {
-              "$ref": "#/definitions/GoogleJsonErrorContainer"
-            }
+            "$ref": "#/responses/DefaultError"
           }
         }
       }
@@ -47,28 +43,18 @@
           "exceptions:v1"
         ],
         "operationId": "ExceptionsV1ThrowsMultipleExceptions",
-        "parameters": [],
         "responses": {
           "204": {
             "description": "A successful response"
           },
           "400": {
-            "description": "badRequest",
-            "schema": {
-              "$ref": "#/definitions/GoogleJsonErrorContainer"
-            }
+            "$ref": "#/responses/BadRequest"
           },
           "409": {
-            "description": "conflict",
-            "schema": {
-              "$ref": "#/definitions/GoogleJsonErrorContainer"
-            }
+            "$ref": "#/responses/Conflict"
           },
           "default": {
-            "description": "A failed response",
-            "schema": {
-              "$ref": "#/definitions/GoogleJsonErrorContainer"
-            }
+            "$ref": "#/responses/DefaultError"
           }
         }
       }
@@ -79,22 +65,15 @@
           "exceptions:v1"
         ],
         "operationId": "ExceptionsV1ThrowsNotFoundException",
-        "parameters": [],
         "responses": {
           "204": {
             "description": "A successful response"
           },
           "404": {
-            "description": "notFound",
-            "schema": {
-              "$ref": "#/definitions/GoogleJsonErrorContainer"
-            }
+            "$ref": "#/responses/NotFound"
           },
           "default": {
-            "description": "A failed response",
-            "schema": {
-              "$ref": "#/definitions/GoogleJsonErrorContainer"
-            }
+            "$ref": "#/responses/DefaultError"
           }
         }
       }
@@ -105,16 +84,12 @@
           "exceptions:v1"
         ],
         "operationId": "ExceptionsV1ThrowsServiceException",
-        "parameters": [],
         "responses": {
           "204": {
             "description": "A successful response"
           },
           "default": {
-            "description": "A failed response",
-            "schema": {
-              "$ref": "#/definitions/GoogleJsonErrorContainer"
-            }
+            "$ref": "#/responses/DefaultError"
           }
         }
       }
@@ -125,16 +100,12 @@
           "exceptions:v1"
         ],
         "operationId": "ExceptionsV1ThrowsUnknownException",
-        "parameters": [],
         "responses": {
           "204": {
             "description": "A successful response"
           },
           "default": {
-            "description": "A failed response",
-            "schema": {
-              "$ref": "#/definitions/GoogleJsonErrorContainer"
-            }
+            "$ref": "#/responses/DefaultError"
           }
         }
       }
@@ -179,6 +150,32 @@
             }
           }
         }
+      }
+    }
+  },
+  "responses": {
+    "BadRequest": {
+      "description": "Bad Request",
+      "schema": {
+        "$ref": "#/definitions/GoogleJsonErrorContainer"
+      }
+    },
+    "Conflict": {
+      "description": "Conflict",
+      "schema": {
+        "$ref": "#/definitions/GoogleJsonErrorContainer"
+      }
+    },
+    "DefaultError": {
+      "description": "A failed response",
+      "schema": {
+        "$ref": "#/definitions/GoogleJsonErrorContainer"
+      }
+    },
+    "NotFound": {
+      "description": "Not Found",
+      "schema": {
+        "$ref": "#/definitions/GoogleJsonErrorContainer"
       }
     }
   }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/error_codes_default_response.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/error_codes_default_response.swagger
@@ -27,16 +27,12 @@
           "exceptions:v1"
         ],
         "operationId": "ExceptionsV1DoesNotThrow",
-        "parameters": [],
         "responses": {
           "204": {
             "description": "A successful response"
           },
           "default": {
-            "description": "A failed response",
-            "schema": {
-              "$ref": "#/definitions/GoogleJsonErrorContainer"
-            }
+            "$ref": "#/responses/DefaultError"
           }
         }
       }
@@ -47,16 +43,12 @@
           "exceptions:v1"
         ],
         "operationId": "ExceptionsV1ThrowsMultipleExceptions",
-        "parameters": [],
         "responses": {
           "204": {
             "description": "A successful response"
           },
           "default": {
-            "description": "A failed response",
-            "schema": {
-              "$ref": "#/definitions/GoogleJsonErrorContainer"
-            }
+            "$ref": "#/responses/DefaultError"
           }
         }
       }
@@ -67,16 +59,12 @@
           "exceptions:v1"
         ],
         "operationId": "ExceptionsV1ThrowsNotFoundException",
-        "parameters": [],
         "responses": {
           "204": {
             "description": "A successful response"
           },
           "default": {
-            "description": "A failed response",
-            "schema": {
-              "$ref": "#/definitions/GoogleJsonErrorContainer"
-            }
+            "$ref": "#/responses/DefaultError"
           }
         }
       }
@@ -87,16 +75,12 @@
           "exceptions:v1"
         ],
         "operationId": "ExceptionsV1ThrowsServiceException",
-        "parameters": [],
         "responses": {
           "204": {
             "description": "A successful response"
           },
           "default": {
-            "description": "A failed response",
-            "schema": {
-              "$ref": "#/definitions/GoogleJsonErrorContainer"
-            }
+            "$ref": "#/responses/DefaultError"
           }
         }
       }
@@ -107,16 +91,12 @@
           "exceptions:v1"
         ],
         "operationId": "ExceptionsV1ThrowsUnknownException",
-        "parameters": [],
         "responses": {
           "204": {
             "description": "A successful response"
           },
           "default": {
-            "description": "A failed response",
-            "schema": {
-              "$ref": "#/definitions/GoogleJsonErrorContainer"
-            }
+            "$ref": "#/responses/DefaultError"
           }
         }
       }
@@ -161,6 +141,14 @@
             }
           }
         }
+      }
+    }
+  },
+  "responses": {
+    "DefaultError": {
+      "description": "A failed response",
+      "schema": {
+        "$ref": "#/definitions/GoogleJsonErrorContainer"
       }
     }
   }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/error_codes_service_exceptions.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/error_codes_service_exceptions.swagger
@@ -27,7 +27,6 @@
           "exceptions:v1"
         ],
         "operationId": "ExceptionsV1DoesNotThrow",
-        "parameters": [],
         "responses": {
           "204": {
             "description": "A successful response"
@@ -41,22 +40,15 @@
           "exceptions:v1"
         ],
         "operationId": "ExceptionsV1ThrowsMultipleExceptions",
-        "parameters": [],
         "responses": {
           "204": {
             "description": "A successful response"
           },
           "400": {
-            "description": "badRequest",
-            "schema": {
-              "$ref": "#/definitions/GoogleJsonErrorContainer"
-            }
+            "$ref": "#/responses/BadRequest"
           },
           "409": {
-            "description": "conflict",
-            "schema": {
-              "$ref": "#/definitions/GoogleJsonErrorContainer"
-            }
+            "$ref": "#/responses/Conflict"
           }
         }
       }
@@ -67,16 +59,12 @@
           "exceptions:v1"
         ],
         "operationId": "ExceptionsV1ThrowsNotFoundException",
-        "parameters": [],
         "responses": {
           "204": {
             "description": "A successful response"
           },
           "404": {
-            "description": "notFound",
-            "schema": {
-              "$ref": "#/definitions/GoogleJsonErrorContainer"
-            }
+            "$ref": "#/responses/NotFound"
           }
         }
       }
@@ -87,7 +75,6 @@
           "exceptions:v1"
         ],
         "operationId": "ExceptionsV1ThrowsServiceException",
-        "parameters": [],
         "responses": {
           "204": {
             "description": "A successful response"
@@ -101,7 +88,6 @@
           "exceptions:v1"
         ],
         "operationId": "ExceptionsV1ThrowsUnknownException",
-        "parameters": [],
         "responses": {
           "204": {
             "description": "A successful response"
@@ -149,6 +135,26 @@
             }
           }
         }
+      }
+    }
+  },
+  "responses": {
+    "BadRequest": {
+      "description": "Bad Request",
+      "schema": {
+        "$ref": "#/definitions/GoogleJsonErrorContainer"
+      }
+    },
+    "Conflict": {
+      "description": "Conflict",
+      "schema": {
+        "$ref": "#/definitions/GoogleJsonErrorContainer"
+      }
+    },
+    "NotFound": {
+      "description": "Not Found",
+      "schema": {
+        "$ref": "#/definitions/GoogleJsonErrorContainer"
       }
     }
   }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint.swagger
@@ -67,7 +67,6 @@
           "foo:v1"
         ],
         "operationId": "FooV1Toplevel",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -143,8 +142,8 @@
           },
           {
             "in": "body",
-            "name": "body",
-            "required": false,
+            "name" : "Foo",
+            "required": true,
             "schema": {
               "$ref": "#/definitions/Foo"
             }
@@ -187,8 +186,8 @@
           },
           {
             "in": "body",
-            "name": "body",
-            "required": false,
+            "name" : "Foo",
+            "required": true,
             "schema": {
               "$ref": "#/definitions/Foo"
             }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint.swagger
@@ -43,7 +43,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A CollectionResponse_Foo response",
             "schema": {
               "$ref": "#/definitions/CollectionResponse_Foo"
             }
@@ -69,7 +69,7 @@
         "operationId": "FooV1Toplevel",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A CollectionResponse_Foo response",
             "schema": {
               "$ref": "#/definitions/CollectionResponse_Foo"
             }
@@ -107,7 +107,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Foo response",
             "schema": {
               "$ref": "#/definitions/Foo"
             }
@@ -142,7 +142,7 @@
           },
           {
             "in": "body",
-            "name" : "Foo",
+            "name": "Foo",
             "required": true,
             "schema": {
               "$ref": "#/definitions/Foo"
@@ -151,7 +151,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Foo response",
             "schema": {
               "$ref": "#/definitions/Foo"
             }
@@ -186,7 +186,7 @@
           },
           {
             "in": "body",
-            "name" : "Foo",
+            "name": "Foo",
             "required": true,
             "schema": {
               "$ref": "#/definitions/Foo"
@@ -195,7 +195,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Foo response",
             "schema": {
               "$ref": "#/definitions/Foo"
             }
@@ -231,7 +231,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Foo response",
             "schema": {
               "$ref": "#/definitions/Foo"
             }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_api_name.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_api_name.swagger
@@ -2,10 +2,10 @@
   "swagger": "2.0",
   "info": {
     "version": "1.0.0",
-    "title": "localhost:8080"
+    "title": "myapi.appspot.com"
   },
-  "host": "localhost:8080",
-  "basePath": "/api",
+  "host": "myapi.appspot.com",
+  "basePath": "/_ah/api",
   "tags": [
     {
       "name": "foo:v1",
@@ -16,7 +16,7 @@
     }
   ],
   "schemes": [
-    "http"
+    "https"
   ],
   "consumes": [
     "application/json"
@@ -303,5 +303,6 @@
         }
       }
     }
-  }
+  },
+  "x-google-api-name": "customApiName"
 }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_combine_all_params.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_combine_all_params.swagger
@@ -38,7 +38,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A CollectionResponse_Foo response",
             "schema": {
               "$ref": "#/definitions/CollectionResponse_Foo"
             }
@@ -66,7 +66,7 @@
         "operationId": "FooV1ListFooosInPath",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A CollectionResponse_Foo response",
             "schema": {
               "$ref": "#/definitions/CollectionResponse_Foo"
             }
@@ -103,7 +103,7 @@
         "operationId": "FooV1ListFooosNotRequired",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A CollectionResponse_Foo response",
             "schema": {
               "$ref": "#/definitions/CollectionResponse_Foo"
             }
@@ -146,7 +146,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A CollectionResponse_Foo response",
             "schema": {
               "$ref": "#/definitions/CollectionResponse_Foo"
             }
@@ -172,7 +172,7 @@
         "operationId": "FooV1Toplevel",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A CollectionResponse_Foo response",
             "schema": {
               "$ref": "#/definitions/CollectionResponse_Foo"
             }
@@ -201,7 +201,7 @@
         "operationId": "FooV1GetFoo",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Foo response",
             "schema": {
               "$ref": "#/definitions/Foo"
             }
@@ -233,7 +233,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Foo response",
             "schema": {
               "$ref": "#/definitions/Foo"
             }
@@ -265,7 +265,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Foo response",
             "schema": {
               "$ref": "#/definitions/Foo"
             }
@@ -292,7 +292,7 @@
         "operationId": "FooV1DeleteFoo",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Foo response",
             "schema": {
               "$ref": "#/definitions/Foo"
             }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_combine_all_params.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_combine_all_params.swagger
@@ -33,7 +33,7 @@
         "operationId": "FooV1ListFooos",
         "parameters": [
           {
-            "$ref": "#/parameters/n"
+            "$ref": "#/parameters/n_query_parameter"
           }
         ],
         "responses": {
@@ -64,7 +64,6 @@
           "foo:v1"
         ],
         "operationId": "FooV1ListFooosInPath",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -102,7 +101,6 @@
           "foo:v1"
         ],
         "operationId": "FooV1ListFooosNotRequired",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -143,7 +141,7 @@
         "operationId": "FooV1ListFoos",
         "parameters": [
           {
-            "$ref": "#/parameters/n"
+            "$ref": "#/parameters/n_query_parameter"
           }
         ],
         "responses": {
@@ -172,7 +170,6 @@
           "foo:v1"
         ],
         "operationId": "FooV1Toplevel",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -202,7 +199,6 @@
         ],
         "description": "get desc",
         "operationId": "FooV1GetFoo",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -232,12 +228,7 @@
         "operationId": "FooV1UpdateFoo",
         "parameters": [
           {
-            "in": "body",
-            "name": "body",
-            "required": false,
-            "schema": {
-              "$ref": "#/definitions/Foo"
-            }
+            "$ref": "#/parameters/Foo_body_parameter"
           }
         ],
         "responses": {
@@ -269,12 +260,7 @@
         "operationId": "FooV1CreateFoo",
         "parameters": [
           {
-            "in": "body",
-            "name": "body",
-            "required": false,
-            "schema": {
-              "$ref": "#/definitions/Foo"
-            }
+            "$ref": "#/parameters/Foo_body_parameter"
           }
         ],
         "responses": {
@@ -304,7 +290,6 @@
         ],
         "description": "delete desc",
         "operationId": "FooV1DeleteFoo",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -390,7 +375,15 @@
     }
   },
   "parameters": {
-    "n": {
+    "Foo_body_parameter": {
+      "in": "body",
+      "name": "Foo",
+      "required": true,
+      "schema": {
+        "$ref": "#/definitions/Foo"
+      }
+    },
+    "n_query_parameter": {
       "name": "n",
       "in": "query",
       "required": true,

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_combine_params_same_path.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_combine_params_same_path.swagger
@@ -33,7 +33,7 @@
         "operationId": "FooV1ListFooos",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A CollectionResponse_Foo response",
             "schema": {
               "$ref": "#/definitions/CollectionResponse_Foo"
             }
@@ -70,7 +70,7 @@
         "operationId": "FooV1ListFooosInPath",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A CollectionResponse_Foo response",
             "schema": {
               "$ref": "#/definitions/CollectionResponse_Foo"
             }
@@ -107,7 +107,7 @@
         "operationId": "FooV1ListFooosNotRequired",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A CollectionResponse_Foo response",
             "schema": {
               "$ref": "#/definitions/CollectionResponse_Foo"
             }
@@ -154,7 +154,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A CollectionResponse_Foo response",
             "schema": {
               "$ref": "#/definitions/CollectionResponse_Foo"
             }
@@ -180,7 +180,7 @@
         "operationId": "FooV1Toplevel",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A CollectionResponse_Foo response",
             "schema": {
               "$ref": "#/definitions/CollectionResponse_Foo"
             }
@@ -209,7 +209,7 @@
         "operationId": "FooV1GetFoo",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Foo response",
             "schema": {
               "$ref": "#/definitions/Foo"
             }
@@ -237,7 +237,7 @@
         "parameters": [
           {
             "in": "body",
-            "name" : "Foo",
+            "name": "Foo",
             "required": true,
             "schema": {
               "$ref": "#/definitions/Foo"
@@ -246,7 +246,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Foo response",
             "schema": {
               "$ref": "#/definitions/Foo"
             }
@@ -274,7 +274,7 @@
         "parameters": [
           {
             "in": "body",
-            "name" : "Foo",
+            "name": "Foo",
             "required": true,
             "schema": {
               "$ref": "#/definitions/Foo"
@@ -283,7 +283,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Foo response",
             "schema": {
               "$ref": "#/definitions/Foo"
             }
@@ -310,7 +310,7 @@
         "operationId": "FooV1DeleteFoo",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Foo response",
             "schema": {
               "$ref": "#/definitions/Foo"
             }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_combine_params_same_path.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_combine_params_same_path.swagger
@@ -31,7 +31,6 @@
           "foo:v1"
         ],
         "operationId": "FooV1ListFooos",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -69,7 +68,6 @@
           "foo:v1"
         ],
         "operationId": "FooV1ListFooosInPath",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -107,7 +105,6 @@
           "foo:v1"
         ],
         "operationId": "FooV1ListFooosNotRequired",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -181,7 +178,6 @@
           "foo:v1"
         ],
         "operationId": "FooV1Toplevel",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -211,7 +207,6 @@
         ],
         "description": "get desc",
         "operationId": "FooV1GetFoo",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -242,8 +237,8 @@
         "parameters": [
           {
             "in": "body",
-            "name": "body",
-            "required": false,
+            "name" : "Foo",
+            "required": true,
             "schema": {
               "$ref": "#/definitions/Foo"
             }
@@ -279,8 +274,8 @@
         "parameters": [
           {
             "in": "body",
-            "name": "body",
-            "required": false,
+            "name" : "Foo",
+            "required": true,
             "schema": {
               "$ref": "#/definitions/Foo"
             }
@@ -313,7 +308,6 @@
         ],
         "description": "delete desc",
         "operationId": "FooV1DeleteFoo",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_default_context.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_default_context.swagger
@@ -67,7 +67,6 @@
           "foo:v1"
         ],
         "operationId": "FooV1Toplevel",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -143,8 +142,8 @@
           },
           {
             "in": "body",
-            "name": "body",
-            "required": false,
+            "name" : "Foo",
+            "required": true,
             "schema": {
               "$ref": "#/definitions/Foo"
             }
@@ -187,8 +186,8 @@
           },
           {
             "in": "body",
-            "name": "body",
-            "required": false,
+            "name" : "Foo",
+            "required": true,
             "schema": {
               "$ref": "#/definitions/Foo"
             }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_default_context.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_default_context.swagger
@@ -43,7 +43,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A CollectionResponse_Foo response",
             "schema": {
               "$ref": "#/definitions/CollectionResponse_Foo"
             }
@@ -69,7 +69,7 @@
         "operationId": "FooV1Toplevel",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A CollectionResponse_Foo response",
             "schema": {
               "$ref": "#/definitions/CollectionResponse_Foo"
             }
@@ -107,7 +107,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Foo response",
             "schema": {
               "$ref": "#/definitions/Foo"
             }
@@ -142,7 +142,7 @@
           },
           {
             "in": "body",
-            "name" : "Foo",
+            "name": "Foo",
             "required": true,
             "schema": {
               "$ref": "#/definitions/Foo"
@@ -151,7 +151,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Foo response",
             "schema": {
               "$ref": "#/definitions/Foo"
             }
@@ -186,7 +186,7 @@
           },
           {
             "in": "body",
-            "name" : "Foo",
+            "name": "Foo",
             "required": true,
             "schema": {
               "$ref": "#/definitions/Foo"
@@ -195,7 +195,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Foo response",
             "schema": {
               "$ref": "#/definitions/Foo"
             }
@@ -231,7 +231,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Foo response",
             "schema": {
               "$ref": "#/definitions/Foo"
             }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_extract_param_refs.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_extract_param_refs.swagger
@@ -33,7 +33,7 @@
         "operationId": "FooV1ListFooos",
         "parameters": [
           {
-            "$ref": "#/parameters/n"
+            "$ref": "#/parameters/n_query_parameter"
           }
         ],
         "responses": {
@@ -141,7 +141,7 @@
         "operationId": "FooV1ListFoos",
         "parameters": [
           {
-            "$ref": "#/parameters/n"
+            "$ref": "#/parameters/n_query_parameter"
           }
         ],
         "responses": {
@@ -170,7 +170,6 @@
           "foo:v1"
         ],
         "operationId": "FooV1Toplevel",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -202,11 +201,7 @@
         "operationId": "FooV1GetFoo",
         "parameters": [
           {
-            "name": "id",
-            "in": "path",
-            "description": "id desc",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/id_path_parameter"
           }
         ],
         "responses": {
@@ -238,19 +233,10 @@
         "operationId": "FooV1UpdateFoo",
         "parameters": [
           {
-            "name": "id",
-            "in": "path",
-            "description": "id desc",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/id_path_parameter"
           },
           {
-            "in": "body",
-            "name": "body",
-            "required": false,
-            "schema": {
-              "$ref": "#/definitions/Foo"
-            }
+            "$ref": "#/parameters/Foo_body_parameter"
           }
         ],
         "responses": {
@@ -282,19 +268,10 @@
         "operationId": "FooV1CreateFoo",
         "parameters": [
           {
-            "name": "id",
-            "in": "path",
-            "description": "id desc",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/id_path_parameter"
           },
           {
-            "in": "body",
-            "name": "body",
-            "required": false,
-            "schema": {
-              "$ref": "#/definitions/Foo"
-            }
+            "$ref": "#/parameters/Foo_body_parameter"
           }
         ],
         "responses": {
@@ -326,11 +303,7 @@
         "operationId": "FooV1DeleteFoo",
         "parameters": [
           {
-            "name": "id",
-            "in": "path",
-            "description": "id desc",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/id_path_parameter"
           }
         ],
         "responses": {
@@ -409,7 +382,22 @@
     }
   },
   "parameters": {
-    "n": {
+    "Foo_body_parameter": {
+      "in": "body",
+      "name": "Foo",
+      "required": true,
+      "schema": {
+        "$ref": "#/definitions/Foo"
+      }
+    },
+    "id_path_parameter": {
+      "name": "id",
+      "in": "path",
+      "description": "id desc",
+      "required": true,
+      "type": "string"
+    },
+    "n_query_parameter": {
       "name": "n",
       "in": "query",
       "required": true,

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_extract_param_refs.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_extract_param_refs.swagger
@@ -38,7 +38,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A CollectionResponse_Foo response",
             "schema": {
               "$ref": "#/definitions/CollectionResponse_Foo"
             }
@@ -75,7 +75,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A CollectionResponse_Foo response",
             "schema": {
               "$ref": "#/definitions/CollectionResponse_Foo"
             }
@@ -112,7 +112,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A CollectionResponse_Foo response",
             "schema": {
               "$ref": "#/definitions/CollectionResponse_Foo"
             }
@@ -146,7 +146,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A CollectionResponse_Foo response",
             "schema": {
               "$ref": "#/definitions/CollectionResponse_Foo"
             }
@@ -172,7 +172,7 @@
         "operationId": "FooV1Toplevel",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A CollectionResponse_Foo response",
             "schema": {
               "$ref": "#/definitions/CollectionResponse_Foo"
             }
@@ -206,7 +206,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Foo response",
             "schema": {
               "$ref": "#/definitions/Foo"
             }
@@ -241,7 +241,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Foo response",
             "schema": {
               "$ref": "#/definitions/Foo"
             }
@@ -276,7 +276,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Foo response",
             "schema": {
               "$ref": "#/definitions/Foo"
             }
@@ -308,7 +308,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Foo response",
             "schema": {
               "$ref": "#/definitions/Foo"
             }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_localhost.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_localhost.swagger
@@ -67,7 +67,6 @@
           "foo:v1"
         ],
         "operationId": "FooV1Toplevel",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -143,8 +142,8 @@
           },
           {
             "in": "body",
-            "name": "body",
-            "required": false,
+            "name" : "Foo",
+            "required": true,
             "schema": {
               "$ref": "#/definitions/Foo"
             }
@@ -187,8 +186,8 @@
           },
           {
             "in": "body",
-            "name": "body",
-            "required": false,
+            "name" : "Foo",
+            "required": true,
             "schema": {
               "$ref": "#/definitions/Foo"
             }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_localhost.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_localhost.swagger
@@ -43,7 +43,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A CollectionResponse_Foo response",
             "schema": {
               "$ref": "#/definitions/CollectionResponse_Foo"
             }
@@ -69,7 +69,7 @@
         "operationId": "FooV1Toplevel",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A CollectionResponse_Foo response",
             "schema": {
               "$ref": "#/definitions/CollectionResponse_Foo"
             }
@@ -107,7 +107,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Foo response",
             "schema": {
               "$ref": "#/definitions/Foo"
             }
@@ -142,7 +142,7 @@
           },
           {
             "in": "body",
-            "name" : "Foo",
+            "name": "Foo",
             "required": true,
             "schema": {
               "$ref": "#/definitions/Foo"
@@ -151,7 +151,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Foo response",
             "schema": {
               "$ref": "#/definitions/Foo"
             }
@@ -186,7 +186,7 @@
           },
           {
             "in": "body",
-            "name" : "Foo",
+            "name": "Foo",
             "required": true,
             "schema": {
               "$ref": "#/definitions/Foo"
@@ -195,7 +195,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Foo response",
             "schema": {
               "$ref": "#/definitions/Foo"
             }
@@ -231,7 +231,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Foo response",
             "schema": {
               "$ref": "#/definitions/Foo"
             }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_with_description_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_with_description_endpoint.swagger
@@ -75,7 +75,6 @@
           "foo:v1"
         ],
         "operationId": "FooV1Toplevel",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -151,8 +150,8 @@
           },
           {
             "in": "body",
-            "name": "body",
-            "required": false,
+            "name": "FooDescription",
+            "required": true,
             "schema": {
               "$ref": "#/definitions/FooDescription"
             }
@@ -195,8 +194,9 @@
           },
           {
             "in": "body",
-            "name": "body",
-            "required": false,
+            "name": "FooDescription",
+            "description": "Description at method parameter level",
+            "required": true,
             "schema": {
               "$ref": "#/definitions/FooDescription"
             }
@@ -320,7 +320,8 @@
           "format": "int32",
           "description": "description of value"
         }
-      }
+      },
+      "description": "Description at class level"
     }
   }
 }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_with_description_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_with_description_endpoint.swagger
@@ -51,7 +51,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A CollectionResponse_FooDescription response",
             "schema": {
               "$ref": "#/definitions/CollectionResponse_FooDescription"
             }
@@ -77,7 +77,7 @@
         "operationId": "FooV1Toplevel",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A CollectionResponse_FooDescription response",
             "schema": {
               "$ref": "#/definitions/CollectionResponse_FooDescription"
             }
@@ -115,7 +115,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A FooDescription response",
             "schema": {
               "$ref": "#/definitions/FooDescription"
             }
@@ -159,7 +159,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A FooDescription response",
             "schema": {
               "$ref": "#/definitions/FooDescription"
             }
@@ -204,7 +204,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A FooDescription response",
             "schema": {
               "$ref": "#/definitions/FooDescription"
             }
@@ -240,7 +240,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A FooDescription response",
             "schema": {
               "$ref": "#/definitions/FooDescription"
             }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/google_auth.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/google_auth.swagger
@@ -27,7 +27,6 @@
           "thirdparty:v1"
         ],
         "operationId": "ThirdpartyV1AuthOverride",
-        "parameters": [],
         "responses": {
           "204": {
             "description": "A successful response"
@@ -46,7 +45,6 @@
           "thirdparty:v1"
         ],
         "operationId": "ThirdpartyV1GoogleAuth",
-        "parameters": [],
         "responses": {
           "204": {
             "description": "A successful response"
@@ -67,7 +65,6 @@
           "thirdparty:v1"
         ],
         "operationId": "ThirdpartyV1NoOverride",
-        "parameters": [],
         "responses": {
           "204": {
             "description": "A successful response"

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/limit_metrics_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/limit_metrics_endpoint.swagger
@@ -27,7 +27,6 @@
           "limits:v1"
         ],
         "operationId": "LimitsV1CreateFoo",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -49,7 +48,6 @@
           "limits:v1"
         ],
         "operationId": "LimitsV1CustomFoo",
-        "parameters": [],
         "responses": {
           "204": {
             "description": "A successful response"

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/limit_metrics_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/limit_metrics_endpoint.swagger
@@ -29,7 +29,7 @@
         "operationId": "LimitsV1CreateFoo",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Foo response",
             "schema": {
               "$ref": "#/definitions/Foo"
             }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/limit_metrics_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/limit_metrics_endpoint.swagger
@@ -80,6 +80,7 @@
     "metrics": [
       {
         "name": "read",
+        "displayName": "Read requests",
         "valueType": "INT64",
         "metricKind": "GAUGE"
       },
@@ -97,8 +98,7 @@
           "values": {
             "STANDARD": 100
           },
-          "unit": "1/min/{project}",
-          "displayName": "Read requests"
+          "unit": "1/min/{project}"
         },
         {
           "name": "write",

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/map_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/map_endpoint.swagger
@@ -27,7 +27,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetDateTimeKeyMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -47,7 +46,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetMapOfStrings",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -64,7 +62,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetStringCollectionMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -85,7 +82,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetBooleanKeyMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -105,7 +101,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetDateKeyMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -125,7 +120,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetFloatKeyMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -145,7 +139,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetIntKeyMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -165,7 +158,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetLongKeyMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -185,7 +177,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetBazMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -205,7 +196,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetFooMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -225,7 +215,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetIntMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -246,7 +235,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetFooMapMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -269,7 +257,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetStringMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -289,7 +276,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetStringArrayMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -310,7 +296,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetStringValueMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -330,7 +315,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetEnumKeyMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -350,7 +334,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetMapService",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -367,7 +350,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetMapSubclass",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/map_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/map_endpoint.swagger
@@ -29,7 +29,7 @@
         "operationId": "MyapiV1GetDateTimeKeyMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Map_DateTime_String response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -48,7 +48,7 @@
         "operationId": "MyapiV1GetMapOfStrings",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A MapContainer response",
             "schema": {
               "$ref": "#/definitions/MapContainer"
             }
@@ -64,7 +64,7 @@
         "operationId": "MyapiV1GetStringCollectionMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A JsonMap response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -84,7 +84,7 @@
         "operationId": "MyapiV1GetBooleanKeyMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Map_Boolean_String response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -103,7 +103,7 @@
         "operationId": "MyapiV1GetDateKeyMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Map_DateTime_String response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -122,7 +122,7 @@
         "operationId": "MyapiV1GetFloatKeyMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Map_Float_String response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -141,7 +141,7 @@
         "operationId": "MyapiV1GetIntKeyMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Map_Integer_String response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -160,7 +160,7 @@
         "operationId": "MyapiV1GetLongKeyMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Map_Long_String response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -179,7 +179,7 @@
         "operationId": "MyapiV1GetBazMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Map_String_Baz response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -198,7 +198,7 @@
         "operationId": "MyapiV1GetFooMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Map_String_Foo response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -217,7 +217,7 @@
         "operationId": "MyapiV1GetIntMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Map_String_Integer response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -237,7 +237,7 @@
         "operationId": "MyapiV1GetFooMapMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Map_String_Map_String_Foo response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -259,7 +259,7 @@
         "operationId": "MyapiV1GetStringMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Map_String_String response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -278,7 +278,7 @@
         "operationId": "MyapiV1GetStringArrayMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A JsonMap response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -298,7 +298,7 @@
         "operationId": "MyapiV1GetStringValueMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Map_String_StringValue response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -317,7 +317,7 @@
         "operationId": "MyapiV1GetEnumKeyMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Map_TestEnum_String response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -336,7 +336,7 @@
         "operationId": "MyapiV1GetMapService",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A MapEndpoint response",
             "schema": {
               "$ref": "#/definitions/MapEndpoint"
             }
@@ -352,7 +352,7 @@
         "operationId": "MyapiV1GetMapSubclass",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Map_Boolean_Integer response",
             "schema": {
               "type": "object",
               "additionalProperties": {

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/map_endpoint_legacy.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/map_endpoint_legacy.swagger
@@ -27,7 +27,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetDateTimeKeyMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -48,7 +47,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetMapOfStrings",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -65,7 +63,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetStringCollectionMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -86,7 +83,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetBooleanKeyMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -107,7 +103,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetDateKeyMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -128,7 +123,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetFloatKeyMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -149,7 +143,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetIntKeyMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -170,7 +163,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetLongKeyMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -191,7 +183,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetBazMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -212,7 +203,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetFooMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -233,7 +223,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetIntMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -254,7 +243,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetFooMapMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -275,7 +263,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetStringMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -296,7 +283,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetStringArrayMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -317,7 +303,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetStringValueMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -338,7 +323,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetEnumKeyMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -359,7 +343,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetMapService",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -376,7 +359,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetMapSubclass",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/map_endpoint_legacy.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/map_endpoint_legacy.swagger
@@ -29,7 +29,7 @@
         "operationId": "MyapiV1GetDateTimeKeyMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A JsonMap response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -49,7 +49,7 @@
         "operationId": "MyapiV1GetMapOfStrings",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A MapContainer response",
             "schema": {
               "$ref": "#/definitions/MapContainer"
             }
@@ -65,7 +65,7 @@
         "operationId": "MyapiV1GetStringCollectionMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A JsonMap response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -85,7 +85,7 @@
         "operationId": "MyapiV1GetBooleanKeyMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A JsonMap response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -105,7 +105,7 @@
         "operationId": "MyapiV1GetDateKeyMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A JsonMap response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -125,7 +125,7 @@
         "operationId": "MyapiV1GetFloatKeyMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A JsonMap response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -145,7 +145,7 @@
         "operationId": "MyapiV1GetIntKeyMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A JsonMap response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -165,7 +165,7 @@
         "operationId": "MyapiV1GetLongKeyMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A JsonMap response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -185,7 +185,7 @@
         "operationId": "MyapiV1GetBazMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A JsonMap response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -205,7 +205,7 @@
         "operationId": "MyapiV1GetFooMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A JsonMap response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -225,7 +225,7 @@
         "operationId": "MyapiV1GetIntMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A JsonMap response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -245,7 +245,7 @@
         "operationId": "MyapiV1GetFooMapMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A JsonMap response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -265,7 +265,7 @@
         "operationId": "MyapiV1GetStringMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A JsonMap response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -285,7 +285,7 @@
         "operationId": "MyapiV1GetStringArrayMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A JsonMap response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -305,7 +305,7 @@
         "operationId": "MyapiV1GetStringValueMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A JsonMap response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -325,7 +325,7 @@
         "operationId": "MyapiV1GetEnumKeyMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A JsonMap response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -345,7 +345,7 @@
         "operationId": "MyapiV1GetMapService",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A MapEndpoint response",
             "schema": {
               "$ref": "#/definitions/MapEndpoint"
             }
@@ -361,7 +361,7 @@
         "operationId": "MyapiV1GetMapSubclass",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A JsonMap response",
             "schema": {
               "type": "object",
               "additionalProperties": {

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/map_endpoint_with_array.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/map_endpoint_with_array.swagger
@@ -27,7 +27,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetDateTimeKeyMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -47,7 +46,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetMapOfStrings",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -64,7 +62,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetStringCollectionMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -87,7 +84,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetBooleanKeyMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -107,7 +103,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetDateKeyMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -127,7 +122,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetFloatKeyMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -147,7 +141,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetIntKeyMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -167,7 +160,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetLongKeyMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -187,7 +179,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetBazMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -207,7 +198,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetFooMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -227,7 +217,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetIntMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -248,7 +237,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetFooMapMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -271,7 +259,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetStringMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -291,7 +278,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetStringArrayMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -314,7 +300,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetStringValueMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -334,7 +319,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetEnumKeyMap",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -354,7 +338,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetMapService",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -371,7 +354,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1GetMapSubclass",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/map_endpoint_with_array.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/map_endpoint_with_array.swagger
@@ -29,7 +29,7 @@
         "operationId": "MyapiV1GetDateTimeKeyMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Map_DateTime_String response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -48,7 +48,7 @@
         "operationId": "MyapiV1GetMapOfStrings",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A MapContainer response",
             "schema": {
               "$ref": "#/definitions/MapContainer"
             }
@@ -64,7 +64,7 @@
         "operationId": "MyapiV1GetStringCollectionMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Map_String_StringCollection response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -86,7 +86,7 @@
         "operationId": "MyapiV1GetBooleanKeyMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Map_Boolean_String response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -105,7 +105,7 @@
         "operationId": "MyapiV1GetDateKeyMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Map_DateTime_String response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -124,7 +124,7 @@
         "operationId": "MyapiV1GetFloatKeyMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Map_Float_String response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -143,7 +143,7 @@
         "operationId": "MyapiV1GetIntKeyMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Map_Integer_String response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -162,7 +162,7 @@
         "operationId": "MyapiV1GetLongKeyMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Map_Long_String response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -181,7 +181,7 @@
         "operationId": "MyapiV1GetBazMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Map_String_Baz response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -200,7 +200,7 @@
         "operationId": "MyapiV1GetFooMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Map_String_Foo response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -219,7 +219,7 @@
         "operationId": "MyapiV1GetIntMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Map_String_Integer response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -239,7 +239,7 @@
         "operationId": "MyapiV1GetFooMapMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Map_String_Map_String_Foo response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -261,7 +261,7 @@
         "operationId": "MyapiV1GetStringMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Map_String_String response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -280,7 +280,7 @@
         "operationId": "MyapiV1GetStringArrayMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Map_String_StringCollection response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -302,7 +302,7 @@
         "operationId": "MyapiV1GetStringValueMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Map_String_StringValue response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -321,7 +321,7 @@
         "operationId": "MyapiV1GetEnumKeyMap",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Map_TestEnum_String response",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -340,7 +340,7 @@
         "operationId": "MyapiV1GetMapService",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A MapEndpoint response",
             "schema": {
               "$ref": "#/definitions/MapEndpoint"
             }
@@ -356,7 +356,7 @@
         "operationId": "MyapiV1GetMapSubclass",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Map_Boolean_Integer response",
             "schema": {
               "type": "object",
               "additionalProperties": {

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/multi_resource_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/multi_resource_endpoint.swagger
@@ -33,7 +33,6 @@
           "multiresource:v1"
         ],
         "operationId": "MultiresourceV1Get",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -50,7 +49,6 @@
           "multiresource:v1.Resource1"
         ],
         "operationId": "MultiresourceV1Resource1Get",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -67,7 +65,6 @@
           "multiresource:v1.Resource2"
         ],
         "operationId": "MultiresourceV1Resource2Get",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/multi_resource_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/multi_resource_endpoint.swagger
@@ -35,7 +35,7 @@
         "operationId": "MultiresourceV1Get",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Foo response",
             "schema": {
               "$ref": "#/definitions/Foo"
             }
@@ -51,7 +51,7 @@
         "operationId": "MultiresourceV1Resource1Get",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Foo response",
             "schema": {
               "$ref": "#/definitions/Foo"
             }
@@ -67,7 +67,7 @@
         "operationId": "MultiresourceV1Resource2Get",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Foo response",
             "schema": {
               "$ref": "#/definitions/Foo"
             }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/multi_version_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/multi_version_endpoint.swagger
@@ -32,7 +32,7 @@
         "operationId": "MyapiV1Get",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Foo response",
             "schema": {
               "$ref": "#/definitions/Foo"
             }
@@ -48,7 +48,7 @@
         "operationId": "MyapiV2Get",
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "A Foo response",
             "schema": {
               "$ref": "#/definitions/Foo"
             }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/multi_version_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/multi_version_endpoint.swagger
@@ -30,7 +30,6 @@
           "myapi:v1"
         ],
         "operationId": "MyapiV1Get",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",
@@ -47,7 +46,6 @@
           "myapi:v2"
         ],
         "operationId": "MyapiV2Get",
-        "parameters": [],
         "responses": {
           "200": {
             "description": "A successful response",

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/multiple_scopes.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/multiple_scopes.swagger
@@ -27,7 +27,6 @@
           "multipleScopes:v1"
         ],
         "operationId": "MultipleScopesV1NoOverride",
-        "parameters": [],
         "responses": {
           "204": {
             "description": "A successful response"
@@ -53,7 +52,6 @@
           "multipleScopes:v1"
         ],
         "operationId": "MultipleScopesV1OverrideAudience",
-        "parameters": [],
         "responses": {
           "204": {
             "description": "A successful response"
@@ -79,7 +77,6 @@
           "multipleScopes:v1"
         ],
         "operationId": "MultipleScopesV1ScopeOverride",
-        "parameters": [],
         "responses": {
           "204": {
             "description": "A successful response"
@@ -105,7 +102,6 @@
           "multipleScopes:v1"
         ],
         "operationId": "MultipleScopesV1UnknownScope",
-        "parameters": [],
         "responses": {
           "204": {
             "description": "A successful response"

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/special_chars.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/special_chars.swagger
@@ -1,0 +1,92 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "swagger-test.appspot.com"
+  },
+  "host": "swagger-test.appspot.com",
+  "basePath": "/api",
+  "tags": [
+    {
+      "name": "specialChars:v1"
+    }
+  ],
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/specialChars/v1/paramSpecialChar1": {
+      "post": {
+        "tags": [
+          "specialChars:v1"
+        ],
+        "operationId": "SpecialCharsV1ParamSpecialChar1",
+        "parameters": [
+          {
+            "$ref": "#/parameters/%C2%B5_query_parameter"
+          },
+          {
+            "in": "body",
+            "name": "Requestù",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Request%C3%B9"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A Responseµ response",
+            "schema": {
+              "$ref": "#/definitions/Response%C2%B5"
+            }
+          }
+        }
+      }
+    },
+    "/specialChars/v1/paramSpecialChar2": {
+      "post": {
+        "tags": [
+          "specialChars:v1"
+        ],
+        "operationId": "SpecialCharsV1ParamSpecialChar2",
+        "parameters": [
+          {
+            "$ref": "#/parameters/%C2%B5_query_parameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A Responseµ response",
+            "schema": {
+              "$ref": "#/definitions/Response%C2%B5"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Requestù": {
+      "type": "object"
+    },
+    "Responseµ": {
+      "type": "object"
+    }
+  },
+  "parameters": {
+    "µ_query_parameter": {
+      "name": "µ",
+      "in": "query",
+      "required": false,
+      "type": "integer",
+      "format": "int32"
+    }
+  }
+}

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/third_party_auth.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/third_party_auth.swagger
@@ -27,7 +27,6 @@
           "thirdparty:v1"
         ],
         "operationId": "ThirdpartyV1AuthOverride",
-        "parameters": [],
         "responses": {
           "204": {
             "description": "A successful response"
@@ -46,7 +45,6 @@
           "thirdparty:v1"
         ],
         "operationId": "ThirdpartyV1NoOverride",
-        "parameters": [],
         "responses": {
           "204": {
             "description": "A successful response"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=2.3.1
+version=2.3.2
 
 sourceCompatibility=1.8
 targetCompatibility=1.8

--- a/test-utils/src/main/java/com/google/api/server/spi/testing/ArrayEndpoint.java
+++ b/test-utils/src/main/java/com/google/api/server/spi/testing/ArrayEndpoint.java
@@ -91,6 +91,9 @@ public class ArrayEndpoint {
   @ApiMethod
   public void setListOfString(@Named("list") List<String> list) {}
 
+  @ApiMethod(path = "setListOfStringAsQueryParam")
+  public void setListOfStringAsQueryParam(@Named("list") List<String> list) {}
+
   @ApiMethod
   public void setListOfBooleans(@Named("list") List<Boolean> list, @Named("array") boolean[] array) {}
 

--- a/test-utils/src/main/java/com/google/api/server/spi/testing/FooDescription.java
+++ b/test-utils/src/main/java/com/google/api/server/spi/testing/FooDescription.java
@@ -16,10 +16,12 @@
 package com.google.api.server.spi.testing;
 
 import com.google.api.server.spi.config.ApiResourceProperty;
+import com.google.api.server.spi.config.Description;
 
 /**
  * Test resource type with descriptions.
  */
+@Description("Description at class level")
 public class FooDescription {
 
   @ApiResourceProperty(description = "description of name")

--- a/test-utils/src/main/java/com/google/api/server/spi/testing/FooDescriptionEndpoint.java
+++ b/test-utils/src/main/java/com/google/api/server/spi/testing/FooDescriptionEndpoint.java
@@ -32,7 +32,8 @@ import com.google.api.server.spi.response.CollectionResponse;
 public class FooDescriptionEndpoint {
   @ApiMethod(name = "foo.create", description = "create desc", path = "foos/{id}",
       httpMethod = HttpMethod.PUT)
-  public FooDescription createFoo(@Named("id") @Description("id desc") String id, FooDescription foo) {
+  public FooDescription createFoo(@Named("id") @Description("id desc") String id, 
+      @Description("Description at method parameter level") FooDescription foo) {
     return null;
   }
   @ApiMethod(name = "foo.get", description = "get desc", path = "foos/{id}",

--- a/test-utils/src/main/java/com/google/api/server/spi/testing/SpecialCharsEndpoint.java
+++ b/test-utils/src/main/java/com/google/api/server/spi/testing/SpecialCharsEndpoint.java
@@ -1,0 +1,28 @@
+package com.google.api.server.spi.testing;
+
+import com.google.api.server.spi.config.Api;
+import com.google.api.server.spi.config.ApiMethod;
+import com.google.api.server.spi.config.Named;
+import com.google.api.server.spi.config.Nullable;
+
+
+@Api(name = "specialChars", version = "v1")
+public class SpecialCharsEndpoint {
+
+  public static class Requestù {
+  }
+  
+  public static class Responseµ {
+  }
+  
+  //checks escaping of param reference
+  @ApiMethod(path = "paramSpecialChar1")
+  public Responseµ paramSpecialChar1(@Named("µ") @Nullable Integer µ, Requestù requestù) {
+    return null;
+  }
+
+  @ApiMethod(path = "paramSpecialChar2")
+  public Responseµ paramSpecialChar2(@Named("µ") @Nullable Integer µ) {
+    return null;
+  }
+}

--- a/test-utils/src/main/java/com/google/api/server/spi/testing/TestEnumDescription.java
+++ b/test-utils/src/main/java/com/google/api/server/spi/testing/TestEnumDescription.java
@@ -17,6 +17,7 @@ package com.google.api.server.spi.testing;
 
 import com.google.api.server.spi.config.Description;
 
+@Description("A list of enum values")
 public enum TestEnumDescription {
   @Description("description of value1")
   VALUE1,


### PR DESCRIPTION
Improve names and descriptions:
- Allow @Description on resources classes and body method params
- Add default description on arrays and maps
- Use the resource name for body params instead of "body"
- Mark request body always required (it acutally is in Cloud Endpoints)

Improve the param extraction logic:
- Extract param ref when a parameter is used in a single path but not on all operations
- Use more unique refs for params by appending type suffix
- Keep param order when replacing by refs

Reduce Swagger spec size:
- nullify empty parameter lists in operations after par combination
- Use spec-level response for errors and improve name / description

Fix some possible validation errors:
- Fix path params collectionFormat (multi is not valid and does not match actual behavior)
- "equivalent" paths must not be allowed

Improve test:
- Add validation of generated Swagger in tests
- Use truth for Discovery tests to be more IDE-friendly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aodocs/endpoints-java/40)
<!-- Reviewable:end -->
