### PR TITLE
Fix handling of empty strings in maps (should be included in response by default)

### DIFF
--- a/endpoints-framework/src/test/java/com/google/api/server/spi/response/CollectionResponseTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/response/CollectionResponseTest.java
@@ -17,6 +17,8 @@ package com.google.api.server.spi.response;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.api.server.spi.config.model.ApiSerializationConfig;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -45,7 +47,8 @@ public class CollectionResponseTest {
   @Test
   public void testCollectionResponse() throws IOException {
     MockHttpServletResponse servletResponse = new MockHttpServletResponse();
-    ServletResponseResultWriter writer = new ServletResponseResultWriter(servletResponse, null);
+    ServletResponseResultWriter writer = new ServletResponseResultWriter(
+        servletResponse, (ApiSerializationConfig) null, false, false);
     writer.write(getBeans(2));
 
     ObjectNode json = new ObjectMapper().readValue(


### PR DESCRIPTION
- Allow "custom" ConfiguredObjectMapper
- Add many test cases for Strings in containers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aodocs/endpoints-java/50)
<!-- Reviewable:end -->
