### PR TITLE
Request parameters validation (#58)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ inactive:
 - Runtime
   - Allow [adding arbitrary data](https://github.com/AODocs/endpoints-java/pull/20) to generic errors
   - [Improve returned errors](https://github.com/AODocs/endpoints-java/pull/30) on malformed JSON
+  - Validate request parameters through [Java bean validation](https://beanvalidation.org/) provided by [Hibernate validator](https://hibernate.org/validator/)
 - Discovery and Swagger
   - [Add description on resources and resource usage as request body](https://github.com/AODocs/endpoints-java/commit/bbb1eff2bb9e7d28fc2ec17599257d0ef610531d)
   - [Support declaring resource properties as required](https://github.com/AODocs/endpoints-java/pull/41)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ inactive:
 - Runtime
   - Allow [adding arbitrary data](https://github.com/AODocs/endpoints-java/pull/20) to generic errors
   - [Improve returned errors](https://github.com/AODocs/endpoints-java/pull/30) on malformed JSON
-  - Validate request parameters through [Java bean validation](https://beanvalidation.org/) provided by [Hibernate validator](https://hibernate.org/validator/)
+  - Validate request parameters/body through [Java bean validation](https://beanvalidation.org/) provided by [Hibernate validator](https://hibernate.org/validator/)
 - Discovery and Swagger
   - [Add description on resources and resource usage as request body](https://github.com/AODocs/endpoints-java/commit/bbb1eff2bb9e7d28fc2ec17599257d0ef610531d)
   - [Support declaring resource properties as required](https://github.com/AODocs/endpoints-java/pull/41)

--- a/endpoints-framework/build.gradle
+++ b/endpoints-framework/build.gradle
@@ -103,7 +103,7 @@ dependencies {
   annotationProcessor group: 'com.google.auto.value', name: 'auto-value', version: autoValueVersion
 
   api group: 'org.hibernate.validator', name: 'hibernate-validator', version: hibernateValidatorVersion
-  api group: 'javax.validation', name: 'validation-api', version: validationApiVersion
+  api group: 'jakarta.validation', name: 'jakarta.validation-api', version: validationApiVersion
 
   testImplementation project(':test-utils')
   testImplementation project(':discovery-client')

--- a/endpoints-framework/build.gradle
+++ b/endpoints-framework/build.gradle
@@ -95,7 +95,9 @@ dependencies {
   compileOnly group: 'com.google.code.findbugs', name: 'jsr305', version: findbugsVersion
   api group: 'commons-fileupload', name: 'commons-fileupload', version: fileUploadVersion
   api group: 'io.swagger', name: 'swagger-models', version: swaggerVersion
-  api group: 'io.swagger', name: 'swagger-core', version: swaggerVersion
+  api(group: 'io.swagger', name: 'swagger-core', version: swaggerVersion) {
+    exclude group: 'javax.validation', module: 'validation-api'
+  }
   compileOnly group: 'org.slf4j', name: 'slf4j-nop', version: slf4jVersion
 
   api group: 'javax.servlet', name: 'servlet-api', version: servletVersion

--- a/endpoints-framework/build.gradle
+++ b/endpoints-framework/build.gradle
@@ -102,6 +102,9 @@ dependencies {
   compileOnly group: 'com.google.auto.value', name: 'auto-value-annotations', version: autoValueVersion
   annotationProcessor group: 'com.google.auto.value', name: 'auto-value', version: autoValueVersion
 
+  api group: 'org.hibernate.validator', name: 'hibernate-validator', version: hibernateValidatorVersion
+  api group: 'javax.validation', name: 'validation-api', version: validationApiVersion
+
   testImplementation project(':test-utils')
   testImplementation project(':discovery-client')
   testImplementation group: 'junit', name: 'junit', version: junitVersion

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/ServletInitializationParameters.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/ServletInitializationParameters.java
@@ -42,7 +42,7 @@ public abstract class ServletInitializationParameters {
   private static final String PRETTY_PRINT = "prettyPrint";
   private static final String ADD_CONTENT_LENGTH = "addContentLength";
   private static final String API_EXPLORER_URL_TEMPLATE = "apiExplorerUrlTemplate";
-  private static final String PARAMETER_VALIDATION = "enableParameterValidation";
+  private static final String PARAMETER_VALIDATION = "enableValidation";
 
   private static final Splitter CSV_SPLITTER = Splitter.on(',').omitEmptyStrings().trimResults();
   private static final Joiner CSV_JOINER = Joiner.on(',').skipNulls();

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/ServletInitializationParameters.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/ServletInitializationParameters.java
@@ -19,7 +19,6 @@ import com.google.auto.value.AutoValue;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 
@@ -43,6 +42,7 @@ public abstract class ServletInitializationParameters {
   private static final String PRETTY_PRINT = "prettyPrint";
   private static final String ADD_CONTENT_LENGTH = "addContentLength";
   private static final String API_EXPLORER_URL_TEMPLATE = "apiExplorerUrlTemplate";
+  private static final String PARAMETER_VALIDATION = "enableParameterValidation";
 
   private static final Splitter CSV_SPLITTER = Splitter.on(',').omitEmptyStrings().trimResults();
   private static final Joiner CSV_JOINER = Joiner.on(',').skipNulls();
@@ -88,6 +88,11 @@ public abstract class ServletInitializationParameters {
    */
   public abstract boolean isAddContentLength();
   
+  /**
+   * Returns whether the request parameter validation is enabled.
+   */
+  public abstract boolean isParameterValidationEnabled();
+  
   @Nullable
   public abstract String getApiExplorerUrlTemplate();
 
@@ -98,6 +103,7 @@ public abstract class ServletInitializationParameters {
         .setExceptionCompatibilityEnabled(true)
         .setPrettyPrintEnabled(true)
         .setAddContentLength(false)
+        .setParameterValidationEnabled(true)
         .setApiExplorerUrlTemplate(null);
   }
 
@@ -141,10 +147,9 @@ public abstract class ServletInitializationParameters {
     public abstract Builder setIllegalArgumentBackendError(boolean illegalArgumentBackendError);
 
     /**
-     * Sets if v1.0 style exceptions should be returned to users. In v1.0, certain codes are not
-     * permissible, and other codes are translated to other status codes. Defaults to {@code true}.
+     * Sets if request parameter validation should be enabled. Defaults to {@code true}.
      */
-    public abstract Builder setExceptionCompatibilityEnabled(boolean exceptionCompatibility);
+    public abstract Builder setParameterValidationEnabled(boolean enabledParameterValidation);
 
     /**
      * Sets if pretty printing should be enabled for responses by default. Defaults to {@code true}.
@@ -163,7 +168,13 @@ public abstract class ServletInitializationParameters {
      * Defaults to http://apis-explorer.appspot.com/apis-explorer/?base=${apiBase} if not set.
      */
     public abstract Builder setApiExplorerUrlTemplate(String urlTemplate);
-
+  
+    /**
+     * Sets if v1.0 style exceptions should be returned to users. In v1.0, certain codes are not
+     * permissible, and other codes are translated to other status codes. Defaults to {@code true}.
+     */
+    public abstract Builder setExceptionCompatibilityEnabled(boolean exceptionCompatibility);
+    
     abstract ServletInitializationParameters autoBuild();
 
     public ServletInitializationParameters build() {
@@ -207,6 +218,11 @@ public abstract class ServletInitializationParameters {
       if (addContentLength != null) {
         builder.setAddContentLength(parseBoolean(addContentLength, ADD_CONTENT_LENGTH));
       }
+      String enabledParameterValidation = config.getInitParameter(PARAMETER_VALIDATION);
+      if (enabledParameterValidation != null) {
+        builder.setParameterValidationEnabled(
+                parseBoolean(enabledParameterValidation, PARAMETER_VALIDATION));
+      }
       builder.setApiExplorerUrlTemplate(config.getInitParameter(API_EXPLORER_URL_TEMPLATE));
     }
     return builder.build();
@@ -243,6 +259,7 @@ public abstract class ServletInitializationParameters {
           put(EXCEPTION_COMPATIBILITY, Boolean.toString(isExceptionCompatibilityEnabled()));
           put(PRETTY_PRINT, Boolean.toString(isPrettyPrintEnabled()));
           put(ADD_CONTENT_LENGTH, Boolean.toString(isAddContentLength()));
+          put(PARAMETER_VALIDATION, Boolean.toString(isParameterValidationEnabled()));
           put(API_EXPLORER_URL_TEMPLATE, getApiExplorerUrlTemplate());
       }};
   }

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/handlers/EndpointsMethodHandler.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/handlers/EndpointsMethodHandler.java
@@ -86,8 +86,8 @@ public class EndpointsMethodHandler {
 
   @VisibleForTesting
   protected ParamReader createRestParamReader(EndpointsContext context,
-      ApiSerializationConfig serializationConfig, Object service) {
-    return new RestServletRequestParamReader(service, endpointMethod, context,
+      ApiSerializationConfig serializationConfig, Object apiService) {
+    return new RestServletRequestParamReader(apiService, endpointMethod, context,
         servletContext, serializationConfig, methodConfig, initParameters.isParameterValidationEnabled());
   }
 

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/handlers/EndpointsMethodHandler.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/handlers/EndpointsMethodHandler.java
@@ -86,9 +86,9 @@ public class EndpointsMethodHandler {
 
   @VisibleForTesting
   protected ParamReader createRestParamReader(EndpointsContext context,
-      ApiSerializationConfig serializationConfig) {
-    return new RestServletRequestParamReader(endpointMethod, context,
-        servletContext, serializationConfig, methodConfig);
+      ApiSerializationConfig serializationConfig, Object service) {
+    return new RestServletRequestParamReader(service, endpointMethod, context,
+        servletContext, serializationConfig, methodConfig, initParameters.isParameterValidationEnabled());
   }
 
   /**
@@ -167,7 +167,7 @@ public class EndpointsMethodHandler {
         Object service = systemService.findService(serviceName);
         ApiSerializationConfig serializationConfig = systemService.getSerializationConfig(
             serviceName);
-        ParamReader reader = createRestParamReader(context, serializationConfig);
+        ParamReader reader = createRestParamReader(context, serializationConfig, service);
         ResultWriter writer = createResultWriter(context, serializationConfig);
         if (request.getHeader(Headers.ORIGIN) != null) {
           HttpServletResponse response = context.getResponse();

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/request/AbstractParamReader.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/request/AbstractParamReader.java
@@ -21,16 +21,16 @@ import com.google.api.server.spi.EndpointMethod;
  * Implementation of functionality common to all implementations of {@link ParamReader}.
  */
 public abstract class AbstractParamReader implements ParamReader {
-  private final Object service;
+  private final Object apiService;
   private final EndpointMethod method;
 
-  protected AbstractParamReader(Object service, EndpointMethod method) {
-    this.service = service;
+  protected AbstractParamReader(Object apiService, EndpointMethod method) {
+    this.apiService = apiService;
     this.method = method;
   }
 
-  protected Object getService() {
-    return service;
+  protected Object getApiService() {
+    return apiService;
   }
 
   protected EndpointMethod getMethod() {

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/request/AbstractParamReader.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/request/AbstractParamReader.java
@@ -21,10 +21,16 @@ import com.google.api.server.spi.EndpointMethod;
  * Implementation of functionality common to all implementations of {@link ParamReader}.
  */
 public abstract class AbstractParamReader implements ParamReader {
+  private final Object service;
   private final EndpointMethod method;
 
-  protected AbstractParamReader(EndpointMethod method) {
+  protected AbstractParamReader(Object service, EndpointMethod method) {
+    this.service = service;
     this.method = method;
+  }
+
+  protected Object getService() {
+    return service;
   }
 
   protected EndpointMethod getMethod() {

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/request/RestServletRequestParamReader.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/request/RestServletRequestParamReader.java
@@ -62,10 +62,10 @@ public class RestServletRequestParamReader extends ServletRequestParamReader {
   private final Map<String, String> rawPathParameters;
   private final Map<String, ApiParameterConfig> parameterConfigMap;
 
-  public RestServletRequestParamReader(EndpointMethod method,
+  public RestServletRequestParamReader(Object service, EndpointMethod method,
       EndpointsContext endpointsContext, ServletContext servletContext,
-      ApiSerializationConfig serializationConfig, ApiMethodConfig methodConfig) {
-    super(method, endpointsContext, servletContext, serializationConfig, methodConfig);
+      ApiSerializationConfig serializationConfig, ApiMethodConfig methodConfig, boolean validationEnabled) {
+    super(service, method, endpointsContext, servletContext, serializationConfig, methodConfig, validationEnabled);
     this.rawPathParameters = endpointsContext.getRawPathParameters();
     ImmutableMap.Builder<String, ApiParameterConfig> builder = ImmutableMap.builder();
     for (ApiParameterConfig config : methodConfig.getParameterConfigs()) {
@@ -157,7 +157,7 @@ public class RestServletRequestParamReader extends ServletRequestParamReader {
           params.put(entry.getKey(), entry.getValue().getDefaultValue());
         }
       }
-      return deserializeParams(body, params);
+      return validateParameters(deserializeParams(body, params));
     } catch (MismatchedInputException e) {
       logger.atInfo().withCause(e).log("Unable to read request parameter(s)");
       throw translateJsonException(e);

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/request/RestServletRequestParamReader.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/request/RestServletRequestParamReader.java
@@ -62,10 +62,10 @@ public class RestServletRequestParamReader extends ServletRequestParamReader {
   private final Map<String, String> rawPathParameters;
   private final Map<String, ApiParameterConfig> parameterConfigMap;
 
-  public RestServletRequestParamReader(Object service, EndpointMethod method,
+  public RestServletRequestParamReader(Object apiService, EndpointMethod method,
       EndpointsContext endpointsContext, ServletContext servletContext,
       ApiSerializationConfig serializationConfig, ApiMethodConfig methodConfig, boolean validationEnabled) {
-    super(service, method, endpointsContext, servletContext, serializationConfig, methodConfig, validationEnabled);
+    super(apiService, method, endpointsContext, servletContext, serializationConfig, methodConfig, validationEnabled);
     this.rawPathParameters = endpointsContext.getRawPathParameters();
     ImmutableMap.Builder<String, ApiParameterConfig> builder = ImmutableMap.builder();
     for (ApiParameterConfig config : methodConfig.getParameterConfigs()) {

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/ServletInitializationParametersTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/ServletInitializationParametersTest.java
@@ -187,7 +187,7 @@ public class ServletInitializationParametersTest {
     assertThat(map.get("enableExceptionCompatibility")).isEqualTo(isExceptionCompatibilityEnabled);
     assertThat(map.get("prettyPrint")).isEqualTo(isPrettyPrintEnabled);
     assertThat(map.get("addContentLength")).isEqualTo(isAddContentLength);
-    assertThat(map.get("enableParameterValidation")).isEqualTo(isParameterValidationEnabled);
+    assertThat(map.get("enableValidation")).isEqualTo(isParameterValidationEnabled);
     assertThat(map.get("apiExplorerUrlTemplate")).isEqualTo(apiExplorerUrlTemplate);
   }
 
@@ -222,7 +222,7 @@ public class ServletInitializationParametersTest {
       initParameters.put("prettyPrint", isPrettyPrintEnabled);
       initParameters.put("addContentLength", isAddContentLength);
       initParameters.put("apiExplorerUrlTemplate", apiExplorerUrlTemplate);
-      initParameters.put("enableParameterValidation", isParameterValidationEnabled);
+      initParameters.put("enableValidation", isParameterValidationEnabled);
     }
 
     @Override

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/ServletInitializationParametersTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/ServletInitializationParametersTest.java
@@ -49,7 +49,8 @@ public class ServletInitializationParametersTest {
     assertThat(initParameters.isPrettyPrintEnabled()).isTrue();
     assertThat(initParameters.isAddContentLength()).isFalse();
     assertThat(initParameters.getApiExplorerUrlTemplate()).isNull();
-    verifyAsMap(initParameters, "", "true", "false", "true", "true", "false", null);
+    assertThat(initParameters.isParameterValidationEnabled()).isTrue();
+    verifyAsMap(initParameters, "", "true", "false", "true", "true", "false", null, "true");
   }
 
   @Test
@@ -62,13 +63,15 @@ public class ServletInitializationParametersTest {
         .setPrettyPrintEnabled(true)
         .setAddContentLength(true)
         .setApiExplorerUrlTemplate("apiExplorer")
+        .setParameterValidationEnabled(true)
         .build();
     assertThat(initParameters.getServiceClasses()).isEmpty();
     assertThat(initParameters.isClientIdWhitelistEnabled()).isTrue();
     assertThat(initParameters.isIllegalArgumentBackendError()).isTrue();
     assertThat(initParameters.isExceptionCompatibilityEnabled()).isTrue();
     assertThat(initParameters.getApiExplorerUrlTemplate()).isEqualTo("apiExplorer");
-    verifyAsMap(initParameters, "", "true", "true", "true", "true", "true", "apiExplorer");
+    assertThat(initParameters.isParameterValidationEnabled()).isTrue();
+    verifyAsMap(initParameters, "", "true", "true", "true", "true", "true", "apiExplorer", "true");
   }
 
   @Test
@@ -80,11 +83,12 @@ public class ServletInitializationParametersTest {
         .setExceptionCompatibilityEnabled(false)
         .setPrettyPrintEnabled(false)
         .setAddContentLength(false)
+        .setParameterValidationEnabled(false)
         .build();
     assertThat(initParameters.getServiceClasses()).containsExactly(String.class);
     assertThat(initParameters.isClientIdWhitelistEnabled()).isFalse();
     verifyAsMap(
-        initParameters, String.class.getName(), "false", "false", "false", "false","false", null);
+        initParameters, String.class.getName(), "false", "false", "false", "false","false", null, "false");
   }
 
   @Test
@@ -94,7 +98,7 @@ public class ServletInitializationParametersTest {
         .build();
     assertThat(initParameters.getServiceClasses()).containsExactly(String.class, Integer.class);
     verifyAsMap(initParameters, String.class.getName() + ',' + Integer.class.getName(), 
-        "true", "false", "true", "true", "false", null);
+        "true", "false", "true", "true", "false", null, "true");
   }
 
   @Test
@@ -108,43 +112,46 @@ public class ServletInitializationParametersTest {
   @Test
   public void testFromServletConfig_nullValues() throws ServletException {
     ServletInitializationParameters initParameters =
-        fromServletConfig(null, null, null, null, null, null, null);
+        fromServletConfig(null, null, null, null, null, null, null, null);
     assertThat(initParameters.getServiceClasses()).isEmpty();
     assertThat(initParameters.isClientIdWhitelistEnabled()).isTrue();
     assertThat(initParameters.isIllegalArgumentBackendError()).isFalse();
     assertThat(initParameters.isExceptionCompatibilityEnabled()).isTrue();
     assertThat(initParameters.isPrettyPrintEnabled()).isTrue();
+    assertThat(initParameters.isParameterValidationEnabled()).isTrue();
     assertThat(initParameters.getApiExplorerUrlTemplate()).isNull();
   }
 
   @Test
   public void testFromServletConfig_emptySetsAndFalse() throws ServletException {
     ServletInitializationParameters initParameters =
-        fromServletConfig("", "false", "false", "false", "false", "false", null);
+        fromServletConfig("", "false", "false", "false", "false", "false", null, "false");
     assertThat(initParameters.getServiceClasses()).isEmpty();
     assertThat(initParameters.isClientIdWhitelistEnabled()).isFalse();
     assertThat(initParameters.isIllegalArgumentBackendError()).isFalse();
     assertThat(initParameters.isExceptionCompatibilityEnabled()).isFalse();
     assertThat(initParameters.isPrettyPrintEnabled()).isFalse();
+    assertThat(initParameters.isParameterValidationEnabled()).isFalse();
     assertThat(initParameters.getApiExplorerUrlTemplate()).isNull();
   }
 
   @Test
   public void testFromServletConfig_oneEntrySetsAndTrue() throws ServletException {
     ServletInitializationParameters initParameters =
-        fromServletConfig(String.class.getName(), "true", "true", "true", "true", "true", null);
+        fromServletConfig(String.class.getName(), "true", "true", "true", "true", "true", null, "true");
     assertThat(initParameters.getServiceClasses()).containsExactly(String.class);
     assertThat(initParameters.isClientIdWhitelistEnabled()).isTrue();
     assertThat(initParameters.isIllegalArgumentBackendError()).isTrue();
     assertThat(initParameters.isExceptionCompatibilityEnabled()).isTrue();
     assertThat(initParameters.isPrettyPrintEnabled()).isTrue();
+    assertThat(initParameters.isParameterValidationEnabled()).isTrue();
     assertThat(initParameters.getApiExplorerUrlTemplate()).isNull();
   }
 
   @Test
   public void testFromServletConfig_twoEntrySets() throws ServletException {
     ServletInitializationParameters initParameters = fromServletConfig(
-        String.class.getName() + ',' + Integer.class.getName(), null, null, null, null, null, null);
+        String.class.getName() + ',' + Integer.class.getName(), null, null, null, null, null, null, null);
     assertThat(initParameters.getServiceClasses()).containsExactly(String.class, Integer.class);
   }
 
@@ -152,14 +159,14 @@ public class ServletInitializationParametersTest {
   public void testFromServletConfig_skipsEmptyElements() throws ServletException {
     ServletInitializationParameters initParameters = fromServletConfig(
         ",," + String.class.getName() + ",,," + Integer.class.getName() + ",", null, null,
-        null, null, null, null);
+        null, null, null, null, null);
     assertThat(initParameters.getServiceClasses()).containsExactly(String.class, Integer.class);
   }
 
   @Test
   public void testFromServletConfig_invalidBooleanThrows() throws ServletException {
     try {
-      fromServletConfig(null, "yes", null, null, null, null, null);
+      fromServletConfig(null, "yes", null, null, null, null, null, null);
       fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException expected) {
       // expected
@@ -170,15 +177,17 @@ public class ServletInitializationParametersTest {
       ServletInitializationParameters initParameters, String serviceClasses,
       String isClientIdWhitelistEnabled,
       String isIllegalArgumentBackendError, String isExceptionCompatibilityEnabled,
-      String isPrettyPrintEnabled, String isAddContentLength, String apiExplorerUrlTemplate) {
+      String isPrettyPrintEnabled, String isAddContentLength, String apiExplorerUrlTemplate,
+      String isParameterValidationEnabled) {
     Map<String, String> map = initParameters.asMap();
-    assertThat(map).hasSize(7);
+    assertThat(map).hasSize(8);
     assertThat(map.get("services")).isEqualTo(serviceClasses);
     assertThat(map.get("clientIdWhitelistEnabled")).isEqualTo(isClientIdWhitelistEnabled);
     assertThat(map.get("illegalArgumentIsBackendError")).isEqualTo(isIllegalArgumentBackendError);
     assertThat(map.get("enableExceptionCompatibility")).isEqualTo(isExceptionCompatibilityEnabled);
     assertThat(map.get("prettyPrint")).isEqualTo(isPrettyPrintEnabled);
     assertThat(map.get("addContentLength")).isEqualTo(isAddContentLength);
+    assertThat(map.get("enableParameterValidation")).isEqualTo(isParameterValidationEnabled);
     assertThat(map.get("apiExplorerUrlTemplate")).isEqualTo(apiExplorerUrlTemplate);
   }
 
@@ -186,11 +195,13 @@ public class ServletInitializationParametersTest {
       String serviceClasses,
       String isClientIdWhitelistEnabled, String isIllegalArgumentBackendError,
       String isExceptionCompatibilityEnabled, String isPrettyPrintEnabled,
-      String isAddContentLength, String apiExplorerUrlTemplate)
+      String isAddContentLength, String apiExplorerUrlTemplate,
+      String isParameterValidationEnabled)
       throws ServletException {
     ServletConfig servletConfig = new StubServletConfig(serviceClasses,
         isClientIdWhitelistEnabled, isIllegalArgumentBackendError,
-        isExceptionCompatibilityEnabled, isPrettyPrintEnabled, isAddContentLength, apiExplorerUrlTemplate);
+        isExceptionCompatibilityEnabled, isPrettyPrintEnabled, isAddContentLength, 
+        apiExplorerUrlTemplate, isParameterValidationEnabled);
     return ServletInitializationParameters.fromServletConfig(
             servletConfig, getClass().getClassLoader());
   }
@@ -201,7 +212,8 @@ public class ServletInitializationParametersTest {
     public StubServletConfig(
         String serviceClasses, String isClientIdWhitelistEnabled,
         String isIllegalArgumentBackendError, String isExceptionCompatibilityEnabled,
-        String isPrettyPrintEnabled, String isAddContentLength, String apiExplorerUrlTemplate) {
+        String isPrettyPrintEnabled, String isAddContentLength, String apiExplorerUrlTemplate,
+        String isParameterValidationEnabled) {
       initParameters = Maps.newHashMap();
       initParameters.put("services", serviceClasses);
       initParameters.put("clientIdWhitelistEnabled", isClientIdWhitelistEnabled);
@@ -210,6 +222,7 @@ public class ServletInitializationParametersTest {
       initParameters.put("prettyPrint", isPrettyPrintEnabled);
       initParameters.put("addContentLength", isAddContentLength);
       initParameters.put("apiExplorerUrlTemplate", apiExplorerUrlTemplate);
+      initParameters.put("enableParameterValidation", isParameterValidationEnabled);
     }
 
     @Override

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/handlers/EndpointsMethodHandlerTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/handlers/EndpointsMethodHandlerTest.java
@@ -152,7 +152,7 @@ public class EndpointsMethodHandlerTest {
     @Override
     @VisibleForTesting
     protected ParamReader createRestParamReader(EndpointsContext context,
-        ApiSerializationConfig serializationConfig) {
+        ApiSerializationConfig serializationConfig, Object service) {
       return new FakeParamReader(params);
     }
 

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/handlers/EndpointsMethodHandlerTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/handlers/EndpointsMethodHandlerTest.java
@@ -152,7 +152,7 @@ public class EndpointsMethodHandlerTest {
     @Override
     @VisibleForTesting
     protected ParamReader createRestParamReader(EndpointsContext context,
-        ApiSerializationConfig serializationConfig, Object service) {
+        ApiSerializationConfig serializationConfig, Object apiService) {
       return new FakeParamReader(params);
     }
 

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/request/RestServletRequestParamReaderTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/request/RestServletRequestParamReaderTest.java
@@ -65,6 +65,7 @@ public class RestServletRequestParamReaderTest {
   public static final SimpleDate NOV_2 = new SimpleDate(2015, 11, 2);
   public static final SimpleDate NOV_1 = new SimpleDate(2015, 11, 1);
 
+  private TestApi service;
   private EndpointMethod endpointMethod;
   private MockHttpServletRequest request;
   private ApiSerializationConfig serializationConfig;
@@ -73,6 +74,7 @@ public class RestServletRequestParamReaderTest {
   
   @Before
   public void setUp() throws Exception {
+    service = new TestApi();
     endpointMethod = EndpointMethod.create(TestApi.class,
         TestApi.class.getMethod("test", Long.TYPE, List.class, TestEnum.class,
             SimpleDate.class, TestResource.class));
@@ -364,8 +366,8 @@ public class RestServletRequestParamReaderTest {
     EndpointsContext endpointsContext =
         new EndpointsContext("GET", "/", request, new MockHttpServletResponse(), true);
     endpointsContext.setRawPathParameters(rawPathParameters);
-    return new RestServletRequestParamReader(endpointMethod, endpointsContext, null,
-        serializationConfig, methodConfig);
+    return new RestServletRequestParamReader(service, endpointMethod, endpointsContext, null,
+        serializationConfig, methodConfig, true);
   }
 
   private void checkContentParseError(String content, String location, String type, String details)

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/request/ServletRequestParamReaderTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/request/ServletRequestParamReaderTest.java
@@ -852,7 +852,7 @@ public class ServletRequestParamReaderTest {
           "{}", EndpointMethod.create(method.getDeclaringClass(), method),
           methodConfig,
           null,
-          null, 
+          null,
           new TestUser());
       fail("expected unauthorized method exception");
     } catch (UnauthorizedException ex) {
@@ -913,7 +913,7 @@ public class ServletRequestParamReaderTest {
                       TestPatternAnnotation.class.getDeclaredMethod("test", String.class), new TestPatternAnnotation());
       fail("expected bad request exception");
     } catch (BadRequestException ex) {
-      assertTrue("failed for unexpected reason: " + ex.getMessage(), ex.getMessage().contains("test.testParam must match"));
+      assertTrue("failed for unexpected reason: " + ex.getMessage(), ex.getMessage().contains("testParam must match"));
     }
   }
   
@@ -940,7 +940,7 @@ public class ServletRequestParamReaderTest {
               TestPatternAnnotation.class.getDeclaredMethod("test", String.class), new TestPatternAnnotation());
       fail("expected bad request exception");
     } catch (BadRequestException ex) {
-      assertTrue("failed for unexpected reason: " + ex.getMessage(), ex.getMessage().contains("test.testParam custom error message"));
+      assertTrue("failed for unexpected reason: " + ex.getMessage(), ex.getMessage().contains("testParam custom error message"));
     }
   }
   
@@ -995,7 +995,7 @@ public class ServletRequestParamReaderTest {
       
       fail("expected bad request exception");
     } catch (BadRequestException ex) {
-      assertTrue("failed for unexpected reason: " + ex.getMessage(), ex.getMessage().contains("test.resource.integerValue must be greater than"));
+      assertTrue("failed for unexpected reason: " + ex.getMessage(), ex.getMessage().contains("resource.integerValue must be greater than"));
     }
   }
 

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/request/ServletRequestParamReaderTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/request/ServletRequestParamReaderTest.java
@@ -53,11 +53,15 @@ import java.util.GregorianCalendar;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TimeZone;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.Pattern;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -137,7 +141,7 @@ public class ServletRequestParamReaderTest {
   public void testReadDate() throws Exception {
     Method method = TestEndpoint.class.getDeclaredMethod("getDate", Date.class);
     Object[] params =
-        readParameters("{" + TestEndpoint.NAME_DATE + ":\"1970-01-01T00:00:00Z\"}", method);
+        readParameters("{" + TestEndpoint.NAME_DATE + ":\"1970-01-01T00:00:00Z\"}", method, new TestEndpoint());
 
     assertEquals(1, params.length);
     assertEquals(new Date(0), params[0]);
@@ -196,7 +200,7 @@ public class ServletRequestParamReaderTest {
     } else {
       builder.replace(builder.length() - 1, builder.length(), "}");
     }
-    Object[] params = readParameters(builder.toString(), method);
+    Object[] params = readParameters(builder.toString(), method, new TestEndpoint());
     assertEquals(15, params.length);
     return params;
   }
@@ -207,7 +211,7 @@ public class ServletRequestParamReaderTest {
     String dateAndTimeString = "2002-10-02T10:00:00-05:00";
 
     Object[] params = readParameters(
-        "{" + TestEndpoint.NAME_DATE_AND_TIME + ":\"" + dateAndTimeString + "\"}", method);
+        "{" + TestEndpoint.NAME_DATE_AND_TIME + ":\"" + dateAndTimeString + "\"}", method, new TestEndpoint());
 
     assertEquals(1, params.length);
     assertEquals(DateAndTime.parseRfc3339String(dateAndTimeString), params[0]);
@@ -219,7 +223,7 @@ public class ServletRequestParamReaderTest {
     Method method = TestEndpoint.class.getDeclaredMethod("getSimpleDate", SimpleDate.class);
     Object[] params = null;
     params = readParameters(
-        "{" + TestEndpoint.NAME_DATE_AND_TIME + ":\"2002-10-02\"}", method);
+        "{" + TestEndpoint.NAME_DATE_AND_TIME + ":\"2002-10-02\"}", method, new TestEndpoint());
     assertThat(Arrays.asList(params)).containsExactly(new SimpleDate(2002, 10, 2)).inOrder();
   }
 
@@ -241,7 +245,7 @@ public class ServletRequestParamReaderTest {
   @Test
   public void testReadNoParameters() throws Exception {
     Method method = TestEndpoint.class.getDeclaredMethod("getResultNoParams");
-    Object[] params = readParameters("", method);
+    Object[] params = readParameters("", method, new TestEndpoint());
     assertEquals(0, params.length);
   }
 
@@ -249,7 +253,7 @@ public class ServletRequestParamReaderTest {
   public void testReadByteArrayParameter() throws Exception {
     Method method =
         TestEndpoint.class.getDeclaredMethod("doSomething", byte[].class);
-    Object[] params = readParameters("{\"bytes\":\"AQIDBA==\"}", method);
+    Object[] params = readParameters("{\"bytes\":\"AQIDBA==\"}", method, new TestEndpoint());
 
     assertEquals(1, params.length);
     assertThat((byte[]) params[0]).isEqualTo(new byte[]{1, 2, 3, 4});
@@ -259,7 +263,7 @@ public class ServletRequestParamReaderTest {
   public void testReadBlobParameter() throws Exception {
     Method method =
         TestEndpoint.class.getDeclaredMethod("doBlob", Blob.class);
-    Object[] params = readParameters("{\"blob\":\"AQIDBA==\"}", method);
+    Object[] params = readParameters("{\"blob\":\"AQIDBA==\"}", method, new TestEndpoint());
 
     assertEquals(1, params.length);
     assertThat(((Blob) params[0]).getBytes()).isEqualTo(new byte[]{1, 2, 3, 4});
@@ -268,7 +272,7 @@ public class ServletRequestParamReaderTest {
   @Test
   public void testReadEnumParameter() throws Exception {
     Method method = TestEndpoint.class.getDeclaredMethod("doEnum", TestEndpoint.TestEnum.class);
-    Object[] params = readParameters("{" + TestEndpoint.NAME_ENUM + ":\"TEST1\"}", method);
+    Object[] params = readParameters("{" + TestEndpoint.NAME_ENUM + ":\"TEST1\"}", method, new TestEndpoint());
 
     assertEquals(1, params.length);
     assertEquals(TestEndpoint.TestEnum.TEST1, params[0]);
@@ -282,7 +286,7 @@ public class ServletRequestParamReaderTest {
     }
     Method method = Test.class.getDeclaredMethod("collection", List.class);
 
-    Object[] params = readParameters("{}", method);
+    Object[] params = readParameters("{}", method, new Test());
     assertEquals(1, params.length);
     @SuppressWarnings("unchecked")
     List<Integer> integers = (List<Integer>) params[0];
@@ -297,7 +301,7 @@ public class ServletRequestParamReaderTest {
     }
     Method method = Test.class.getDeclaredMethod("collection", Integer[].class);
 
-    Object[] params = readParameters("{}", method);
+    Object[] params = readParameters("{}", method, new Test());
     assertEquals(1, params.length);
     @SuppressWarnings("unchecked")
     Integer[] integers = (Integer[]) params[0];
@@ -312,7 +316,7 @@ public class ServletRequestParamReaderTest {
     }
     Method method = Test.class.getDeclaredMethod("collection", Collection.class);
     doTestCollectionParameter(
-        "collection", EndpointMethod.create(Test.class, method));
+        "collection", EndpointMethod.create(Test.class, method), new Test());
   }
 
   @Test
@@ -324,7 +328,7 @@ public class ServletRequestParamReaderTest {
     class Test extends TestGeneric<Integer> {}
     doTestCollectionParameter("collection", EndpointMethod.create(
         Test.class, Test.class.getMethod("collection", Collection.class),
-        TypeToken.of(Test.class).getSupertype(TestGeneric.class)));
+        TypeToken.of(Test.class).getSupertype(TestGeneric.class)), new Test());
   }
 
   @Test
@@ -335,7 +339,7 @@ public class ServletRequestParamReaderTest {
     }
     Method method = Test.class.getDeclaredMethod("collection", List.class);
     doTestCollectionParameter(
-        "list", EndpointMethod.create(Test.class, method));
+        "list", EndpointMethod.create(Test.class, method), new Test());
   }
 
   @Test
@@ -346,7 +350,7 @@ public class ServletRequestParamReaderTest {
     }
     Method method = Test.class.getDeclaredMethod("collection", Set.class);
     doTestSetParameter(
-        "set", EndpointMethod.create(Test.class, method));
+        "set", EndpointMethod.create(Test.class, method), new Test());
   }
 
   @Test
@@ -357,11 +361,11 @@ public class ServletRequestParamReaderTest {
     }
     Method method = Test.class.getDeclaredMethod("array", Integer[].class);
     doTestReadArrayParameter(
-        "array", EndpointMethod.create(Test.class, method));
+        "array", EndpointMethod.create(Test.class, method), new Test());
   }
 
-  private void doTestCollectionParameter(String name, EndpointMethod method) throws Exception {
-    Object[] params = readParameters("{\"" + name + "\":[1,2,3]}", method);
+  private void doTestCollectionParameter(String name, EndpointMethod method, Object service) throws Exception {
+    Object[] params = readParameters("{\"" + name + "\":[1,2,3]}", method, service);
 
     assertEquals(1, params.length);
     @SuppressWarnings("unchecked")
@@ -382,11 +386,11 @@ public class ServletRequestParamReaderTest {
     class Test extends TestGeneric<Integer> {}
     doTestReadArrayParameter("array", EndpointMethod.create(
         Test.class, Test.class.getMethod("array", Object[].class),
-        TypeToken.of(Test.class).getSupertype(TestGeneric.class)));
+        TypeToken.of(Test.class).getSupertype(TestGeneric.class)), new Test());
   }
 
-  private void doTestSetParameter(String name, EndpointMethod method) throws Exception {
-    Object[] params = readParameters("{\"" + name + "\":[1,2,1]}", method);
+  private void doTestSetParameter(String name, EndpointMethod method, Object service) throws Exception {
+    Object[] params = readParameters("{\"" + name + "\":[1,2,1]}", method, service);
 
     assertEquals(1, params.length);
     @SuppressWarnings("unchecked")
@@ -395,8 +399,8 @@ public class ServletRequestParamReaderTest {
     assertTrue(integers.contains(1));
   }
 
-  private void doTestReadArrayParameter(String name, EndpointMethod method) throws Exception {
-    Object[] params = readParameters("{\"" + name + "\":[1,2,3]}", method);
+  private void doTestReadArrayParameter(String name, EndpointMethod method, Object service) throws Exception {
+    Object[] params = readParameters("{\"" + name + "\":[1,2,3]}", method, service);
 
     assertEquals(1, params.length);
     Integer[] integers = (Integer[]) params[0];
@@ -414,7 +418,7 @@ public class ServletRequestParamReaderTest {
     }
     Method method = Test.class.getDeclaredMethod("collection", Collection.class);
     doTestReadCollectionDateParameter(
-        "collection", EndpointMethod.create(Test.class, method));
+        "collection", EndpointMethod.create(Test.class, method), new Test());
   }
 
   @Test
@@ -426,13 +430,13 @@ public class ServletRequestParamReaderTest {
     class Test extends TestGeneric<Date> {}
     doTestReadCollectionDateParameter("collection", EndpointMethod.create(
         Test.class, Test.class.getMethod("collection", Collection.class),
-        TypeToken.of(Test.class).getSupertype(TestGeneric.class)));
+        TypeToken.of(Test.class).getSupertype(TestGeneric.class)), new Test());
   }
 
   private void doTestReadCollectionDateParameter(
-      String name, EndpointMethod method) throws Exception {
+      String name, EndpointMethod method, Object service) throws Exception {
     Object[] params = readParameters(
-        "{\"" + name + "\":[\"2002-10-01\",\"2002-10-02\",\"2002-10-03\"]}", method);
+        "{\"" + name + "\":[\"2002-10-01\",\"2002-10-02\",\"2002-10-03\"]}", method, service);
 
     assertEquals(1, params.length);
     @SuppressWarnings("unchecked")
@@ -452,7 +456,7 @@ public class ServletRequestParamReaderTest {
     }
     Method method = Test.class.getDeclaredMethod("array", Date[].class);
     doTestReadArrayDateParameter(
-        "array", EndpointMethod.create(Test.class, method));
+        "array", EndpointMethod.create(Test.class, method), new Test());
   }
 
   @Test
@@ -464,12 +468,12 @@ public class ServletRequestParamReaderTest {
     class Test extends TestGeneric<Date> {}
     doTestReadArrayDateParameter("array", EndpointMethod.create(
         Test.class, Test.class.getMethod("array", Object[].class),
-        TypeToken.of(Test.class).getSupertype(TestGeneric.class)));
+        TypeToken.of(Test.class).getSupertype(TestGeneric.class)), new Test());
   }
 
-  private void doTestReadArrayDateParameter(String name, EndpointMethod method) throws Exception {
+  private void doTestReadArrayDateParameter(String name, EndpointMethod method, Object service) throws Exception {
     Object[] params = readParameters(
-        "{\"" + name + "\":[\"2002-10-01\",\"2002-10-02\",\"2002-10-03\"]}", method);
+        "{\"" + name + "\":[\"2002-10-01\",\"2002-10-02\",\"2002-10-03\"]}", method, service);
 
     assertEquals(1, params.length);
     Date[] dates = (Date[]) params[0];
@@ -491,7 +495,7 @@ public class ServletRequestParamReaderTest {
     }
     Method method = Test.class.getDeclaredMethod("collection", Collection.class);
     doTestReadCollectionEnumParameter(
-        "collection", EndpointMethod.create(Test.class, method));
+        "collection", EndpointMethod.create(Test.class, method), new Test());
   }
 
   @Test
@@ -503,12 +507,12 @@ public class ServletRequestParamReaderTest {
     class Test extends TestGeneric<Outcome> {}
     doTestReadCollectionEnumParameter("collection", EndpointMethod.create(
         Test.class, Test.class.getMethod("collection", Collection.class),
-        TypeToken.of(Test.class).getSupertype(TestGeneric.class)));
+        TypeToken.of(Test.class).getSupertype(TestGeneric.class)), new Test());
   }
 
   private void doTestReadCollectionEnumParameter(
-      String name, EndpointMethod method) throws Exception {
-    Object[] params = readParameters("{\"" + name + "\":[\"WON\",\"LOST\",\"TIE\"]}", method);
+      String name, EndpointMethod method, Object service) throws Exception {
+    Object[] params = readParameters("{\"" + name + "\":[\"WON\",\"LOST\",\"TIE\"]}", method, service);
 
     assertEquals(1, params.length);
     @SuppressWarnings("unchecked")
@@ -527,7 +531,7 @@ public class ServletRequestParamReaderTest {
       public void array(@Named("array") Outcome[] outcomes) {}
     }
     Method method = Test.class.getDeclaredMethod("array", Outcome[].class);
-    doTestReadArrayEnumParameter("array", EndpointMethod.create(Test.class, method));
+    doTestReadArrayEnumParameter("array", EndpointMethod.create(Test.class, method), new Test());
   }
 
   @Test
@@ -539,11 +543,11 @@ public class ServletRequestParamReaderTest {
     class Test extends TestGeneric<Outcome> {}
     doTestReadArrayEnumParameter("array", EndpointMethod.create(
         Test.class, Test.class.getMethod("array", Object[].class),
-        TypeToken.of(Test.class).getSupertype(TestGeneric.class)));
+        TypeToken.of(Test.class).getSupertype(TestGeneric.class)), new Test());
   }
 
-  private void doTestReadArrayEnumParameter(String name, EndpointMethod method) throws Exception {
-    Object[] params = readParameters("{\"" + name + "\":[\"WON\",\"LOST\",\"TIE\"]}", method);
+  private void doTestReadArrayEnumParameter(String name, EndpointMethod method, Object service) throws Exception {
+    Object[] params = readParameters("{\"" + name + "\":[\"WON\",\"LOST\",\"TIE\"]}", method, service);
 
     assertEquals(1, params.length);
     Outcome[] outcomes = (Outcome[]) params[0];
@@ -569,7 +573,7 @@ public class ServletRequestParamReaderTest {
 
     Method method = TestMultipleResources.class.getDeclaredMethod("foo",
         String.class, Integer[].class, Collection.class, Request.class);
-    Object[] params = readParameters(requestString, method);
+    Object[] params = readParameters(requestString, method, new TestMultipleResources());
 
     assertEquals(4, params.length);
     String string = (String) params[0];
@@ -602,7 +606,7 @@ public class ServletRequestParamReaderTest {
     String requestString = "{\"str\":\"hello\"}";
 
     Method method = Test.class.getDeclaredMethod("foo", String.class, Integer.class);
-    Object[] params = readParameters(requestString, method);
+    Object[] params = readParameters(requestString, method, new Test());
 
     assertEquals(2, params.length);
     assertEquals("hello", params[0]);
@@ -623,7 +627,7 @@ public class ServletRequestParamReaderTest {
 
     String requestString = "{\"name1\":\"v1\", \"foo2\":\"v2\", \"name3\":\"v3\"}";
 
-    Object[] params = readParameters(requestString, endpointMethod);
+    Object[] params = readParameters(requestString, endpointMethod, new Test());
 
     assertEquals(3, params.length);
     assertEquals("v1", params[0]);
@@ -644,7 +648,7 @@ public class ServletRequestParamReaderTest {
     Method method = Test.class.getDeclaredMethod("foo", String.class, String.class, String.class);
     EndpointMethod endpointMethod = EndpointMethod.create(method.getDeclaringClass(), method);
 
-    readParameters("{}", endpointMethod);
+    readParameters("{}", endpointMethod, new Test());
     List<String> parameterNames = endpointMethod.getParameterNames();
 
     assertEquals(3, parameterNames.size());
@@ -668,8 +672,8 @@ public class ServletRequestParamReaderTest {
     final TestUser user = new TestUser("test");
     Method method = TestUserEndpoint.class.getDeclaredMethod("user", TestUser.class);
     ParamReader reader = new ServletRequestParamReader(
-        EndpointMethod.create(method.getDeclaringClass(), method), endpointsContext, context, null,
-        null) {
+            new TestUserEndpoint(), EndpointMethod.create(method.getDeclaringClass(), method), endpointsContext, context, null,
+        null, true) {
       @Override
       User getUser() {
         return user;
@@ -694,7 +698,7 @@ public class ServletRequestParamReaderTest {
     String ip = "9.8.7.6";
     when(request.getRemoteAddr()).thenReturn(ip);
     Object[] params = readParameters("{}",
-        TestUserIp.class.getDeclaredMethod("userIp", String.class));
+        TestUserIp.class.getDeclaredMethod("userIp", String.class), new TestUserIp());
     assertEquals(1, params.length);
     assertEquals(ip, params[0]);
   }
@@ -706,7 +710,7 @@ public class ServletRequestParamReaderTest {
       public void alt(@Named("alt") String alt) {}
     }
     Object[] params = readParameters(
-        "{\"alt\":\"test\"}", TestAlt.class.getDeclaredMethod("alt", String.class));
+        "{\"alt\":\"test\"}", TestAlt.class.getDeclaredMethod("alt", String.class), new TestAlt());
     assertEquals(1, params.length);
     assertEquals("test", params[0]);
   }
@@ -717,7 +721,7 @@ public class ServletRequestParamReaderTest {
       @SuppressWarnings("unused")
       public void alt(@Named("alt") String alt) {}
     }
-    Object[] params = readParameters("{}", TestAlt.class.getDeclaredMethod("alt", String.class));
+    Object[] params = readParameters("{}", TestAlt.class.getDeclaredMethod("alt", String.class), new TestAlt());
     assertEquals(1, params.length);
     assertEquals("json", params[0]);
   }
@@ -729,7 +733,7 @@ public class ServletRequestParamReaderTest {
       public void fields(@Named("fields") String fields) {}
     }
     Object[] params = readParameters(
-        "{\"fields\":\"test\"}", TestFields.class.getDeclaredMethod("fields", String.class));
+        "{\"fields\":\"test\"}", TestFields.class.getDeclaredMethod("fields", String.class), new TestFields());
     assertEquals(1, params.length);
     assertEquals("test", params[0]);
   }
@@ -741,7 +745,7 @@ public class ServletRequestParamReaderTest {
       public void key(@Named("key") String key) {}
     }
     Object[] params = readParameters(
-        "{\"key\":\"test\"}", TestKey.class.getDeclaredMethod("key", String.class));
+        "{\"key\":\"test\"}", TestKey.class.getDeclaredMethod("key", String.class), new TestKey());
     assertEquals(1, params.length);
     assertEquals("test", params[0]);
   }
@@ -754,7 +758,7 @@ public class ServletRequestParamReaderTest {
     }
     Object[] params = readParameters(
         "{\"oauth_token\":\"test\"}",
-        TestOAuthToken.class.getDeclaredMethod("oAuthToken", String.class));
+        TestOAuthToken.class.getDeclaredMethod("oAuthToken", String.class), new TestOAuthToken());
     assertEquals(1, params.length);
     assertEquals("test", params[0]);
   }
@@ -767,7 +771,7 @@ public class ServletRequestParamReaderTest {
     }
     Object[] params = readParameters(
         "{\"quotaUser\":\"test\"}",
-        TestQuotaUser.class.getDeclaredMethod("quotaUser", String.class));
+        TestQuotaUser.class.getDeclaredMethod("quotaUser", String.class), new TestQuotaUser());
     assertEquals(1, params.length);
     assertEquals("test", params[0]);
   }
@@ -780,7 +784,7 @@ public class ServletRequestParamReaderTest {
     }
     when(request.getParameter("prettyPrint")).thenReturn("false");
     Object[] params =
-        readParameters("{}", TestPrettyPrint.class.getDeclaredMethod("prettyPrint", String.class));
+        readParameters("{}", TestPrettyPrint.class.getDeclaredMethod("prettyPrint", String.class), new TestPrettyPrint());
     assertEquals(1, params.length);
     assertEquals(false, params[0]);
   }
@@ -792,7 +796,7 @@ public class ServletRequestParamReaderTest {
       public void prettyPrint(@Named("prettyPrint") String prettyPrint) {}
     }
     Object[] params =
-        readParameters("{}", TestPrettyPrint.class.getDeclaredMethod("prettyPrint", String.class));
+        readParameters("{}", TestPrettyPrint.class.getDeclaredMethod("prettyPrint", String.class), new TestPrettyPrint());
     assertEquals(1, params.length);
     assertEquals(true, params[0]);
   }
@@ -808,7 +812,7 @@ public class ServletRequestParamReaderTest {
         "{\"stringValue\": [\"fromParams\"], \"integerValue\": [1,2,3], " 
             + "\"resource\": {\"stringValue\": \"abc\", \"integerValue\": 42}}",
         TestNameInParamsAndResource.class
-            .getDeclaredMethod("test", List.class, List.class, Request.class));
+            .getDeclaredMethod("test", List.class, List.class, Request.class), new TestNameInParamsAndResource());
     assertEquals(3, params.length);
     assertEquals(Collections.singletonList("fromParams"), params[0]);
     assertEquals(ImmutableList.of(1,2,3), params[1]);
@@ -825,7 +829,7 @@ public class ServletRequestParamReaderTest {
       readParameters(
           "{\"resource\": {\"integerValue\": [42]}}",
           TesTypeMismatch.class
-              .getDeclaredMethod("test", Request.class));
+              .getDeclaredMethod("test", Request.class), new TesTypeMismatch());
       fail("expected bad request exception");
     } catch (BadRequestException e) {
       assertEquals("Parse error for field 'integerValue' of type 'int'", e.getMessage());
@@ -848,7 +852,8 @@ public class ServletRequestParamReaderTest {
           "{}", EndpointMethod.create(method.getDeclaringClass(), method),
           methodConfig,
           null,
-          null);
+          null, 
+          new TestUser());
       fail("expected unauthorized method exception");
     } catch (UnauthorizedException ex) {
       // expected
@@ -873,7 +878,8 @@ public class ServletRequestParamReaderTest {
           EndpointMethod.create(method.getDeclaringClass(), method),
           methodConfig,
           null,
-          null);
+          null,
+          new TestUser());
       fail("expected unauthorized method exception");
     } catch (UnauthorizedException ex) {
       // expected
@@ -889,27 +895,124 @@ public class ServletRequestParamReaderTest {
     try {
       Object[] params =
           readParameters("{}",
-              TestNullValueForRequiredParam.class.getDeclaredMethod("test", String.class));
+              TestNullValueForRequiredParam.class.getDeclaredMethod("test", String.class), new TestNullValueForRequiredParam());
       fail("expected bad request exception");
     } catch (BadRequestException ex) {
       // expected
     }
   }
 
-  private Object[] readParameters(String input, Method method) throws Exception {
-    return readParameters(input, EndpointMethod.create(method.getDeclaringClass(), method));
+  @Test
+  public void testPatternAnnotation_noMatch() throws Exception {
+    class TestPatternAnnotation {
+      @SuppressWarnings("unused")
+      public void test(@Named("testParam") @Pattern(regexp = "^\\d{2}$") String testParam) {}
+    }
+    try {
+      readParameters("{\"testParam\":\"123\"}",
+                      TestPatternAnnotation.class.getDeclaredMethod("test", String.class), new TestPatternAnnotation());
+      fail("expected bad request exception");
+    } catch (BadRequestException ex) {
+      assertTrue("failed for unexpected reason: " + ex.getMessage(), ex.getMessage().contains("test.testParam must match"));
+    }
+  }
+  
+  @Test
+  public void testPatternAnnotation_match() throws Exception {
+    class TestPatternAnnotation {
+      @SuppressWarnings("unused")
+      public void test(@Named("testParam") @Pattern(regexp = "^\\d{2}$") String testParam) {}
+    }
+    Object[] params = readParameters("{\"testParam\":\"42\"}", 
+            TestPatternAnnotation.class.getDeclaredMethod("test", String.class), new TestPatternAnnotation());
+    assertEquals(1, params.length);
+    assertEquals("42", params[0]);
+  }
+  
+  @Test
+  public void testPatternAnnotation_customError() throws Exception {
+    class TestPatternAnnotation {
+      @SuppressWarnings("unused")
+      public void test(@Named("testParam") @Pattern(regexp = "^\\d{2}$", message="custom error message") String testParam) {}
+    }
+    try {
+      readParameters("{\"testParam\":\"invalidValue\"}",
+              TestPatternAnnotation.class.getDeclaredMethod("test", String.class), new TestPatternAnnotation());
+      fail("expected bad request exception");
+    } catch (BadRequestException ex) {
+      assertTrue("failed for unexpected reason: " + ex.getMessage(), ex.getMessage().contains("test.testParam custom error message"));
+    }
+  }
+  
+  static class TestPatternAnnotationInResourceRequest {
+    
+    @Min(value = 3)
+    private Integer integerValue;
+    
+    public TestPatternAnnotationInResourceRequest() {
+    }
+    
+    public TestPatternAnnotationInResourceRequest(Integer stringValue) {
+      this.integerValue = stringValue;
+    }
+    
+    public void setIntegerValue(Integer integerValue) {
+      this.integerValue = integerValue;
+    }
+    
+    public Integer getIntegerValue() {
+      return integerValue;
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      TestPatternAnnotationInResourceRequest request = (TestPatternAnnotationInResourceRequest) o;
+      return Objects.equals(integerValue, request.integerValue);
+    }
+    
+    @Override
+    public int hashCode() {
+      return Objects.hash(integerValue);
+    }
+  }
+  
+  @Test
+  public void testValidAnnotationInResource() throws Exception {
+    
+    class TestPatternAnnotationInResource {
+      @SuppressWarnings("unused")
+      public void test(@Valid TestPatternAnnotationInResourceRequest resource) {}
+    }
+    try { 
+      readParameters("{\"resource\":{\"integerValue\":2}}",
+            TestPatternAnnotationInResource.class.getDeclaredMethod("test", TestPatternAnnotationInResourceRequest.class), new TestPatternAnnotationInResource());
+      
+      fail("expected bad request exception");
+    } catch (BadRequestException ex) {
+      assertTrue("failed for unexpected reason: " + ex.getMessage(), ex.getMessage().contains("test.resource.integerValue must be greater than"));
+    }
   }
 
-  private Object[] readParameters(final String input, EndpointMethod method) throws Exception {
-    return readParameters(input, method, null, USER, APP_ENGINE_USER);
+  private Object[] readParameters(String input, Method method, Object service) throws Exception {
+    return readParameters(input, EndpointMethod.create(method.getDeclaringClass(), method), service);
+  }
+
+  private Object[] readParameters(final String input, EndpointMethod method, Object service) throws Exception {
+    return readParameters(input, method, null, USER, APP_ENGINE_USER, service);
   }
 
   private Object[] readParameters(final String input, EndpointMethod method,
       ApiMethodConfig methodConfig, final User user,
-      final com.google.appengine.api.users.User appEngineUser)
+      final com.google.appengine.api.users.User appEngineUser, Object service)
       throws Exception {
-    ParamReader reader = new ServletRequestParamReader(method, endpointsContext, context, null,
-        methodConfig) {
+    ParamReader reader = new ServletRequestParamReader(service, method, endpointsContext, context, null,
+        methodConfig, true) {
       @Override
       User getUser() {
         return user;
@@ -943,7 +1046,7 @@ public class ServletRequestParamReaderTest {
     Method method = TestEndpoint.class.getDeclaredMethod("getSimpleDate", SimpleDate.class);
     try {
       readParameters(
-          "{" + TestEndpoint.NAME_DATE_AND_TIME + ":\"" + simpleDateString + "\"}", method);
+          "{" + TestEndpoint.NAME_DATE_AND_TIME + ":\"" + simpleDateString + "\"}", method, new TestEndpoint());
       fail("Expected BadRequestException");
     } catch (BadRequestException expected) {}
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,8 @@ slf4jVersion=1.7.32
 guiceVersion=4.2.3
 objectifyVersion=5.1.24
 floggerVersion=0.6
+hibernateValidatorVersion=6.2.0.Final
+validationApiVersion=2.0.1.Final
 
 junitVersion=4.13.2
 mockitoVersion=3.6.28

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ guiceVersion=4.2.3
 objectifyVersion=5.1.24
 floggerVersion=0.6
 hibernateValidatorVersion=6.2.0.Final
-validationApiVersion=2.0.1.Final
+validationApiVersion=2.0.2
 
 junitVersion=4.13.2
 mockitoVersion=3.6.28


### PR DESCRIPTION
- Supports request parameters validation through standard Java bean validation
- Validation can be turned off with a servlet parameter : `enableParameterValidation`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aodocs/endpoints-java/59)
<!-- Reviewable:end -->
