### PR TITLE
Support for pattern/min/max in Discovery and Swagger

### DIFF
--- a/endpoints-framework/src/main/java/com/google/api/server/spi/TypeLoader.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/TypeLoader.java
@@ -193,6 +193,14 @@ public final class TypeLoader {
         loadAnnotation(classLoader, "com.google.api.server.spi.config.Nullable"));
     annotationTypes.put("Pattern",
             loadAnnotation(classLoader, "javax.validation.constraints.Pattern"));
+    annotationTypes.put("Min",
+            loadAnnotation(classLoader, "javax.validation.constraints.Min"));
+    annotationTypes.put("Max",
+            loadAnnotation(classLoader, "javax.validation.constraints.Max"));
+    annotationTypes.put("DecimalMin",
+            loadAnnotation(classLoader, "javax.validation.constraints.DecimalMin"));
+    annotationTypes.put("DecimalMax",
+            loadAnnotation(classLoader, "javax.validation.constraints.DecimalMax"));
     return Collections.unmodifiableMap(annotationTypes);
   }
 

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/TypeLoader.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/TypeLoader.java
@@ -191,6 +191,8 @@ public final class TypeLoader {
         loadAnnotation(classLoader, "com.google.api.server.spi.config.Named"));
     annotationTypes.put("Nullable",
         loadAnnotation(classLoader, "com.google.api.server.spi.config.Nullable"));
+    annotationTypes.put("Pattern",
+            loadAnnotation(classLoader, "javax.validation.constraints.Pattern"));
     return Collections.unmodifiableMap(annotationTypes);
   }
 

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/annotationreader/ApiConfigAnnotationReader.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/annotationreader/ApiConfigAnnotationReader.java
@@ -374,13 +374,15 @@ public class ApiConfigAnnotationReader implements ApiConfigSource {
           AnnotationUtil.getNullableParameter(method, i, annotationTypes.get("Nullable"));
       Annotation defaultValue =
           AnnotationUtil.getParameterAnnotation(method, i, annotationTypes.get("DefaultValue"));
+      Annotation pattern =
+              AnnotationUtil.getParameterAnnotation(method, i, annotationTypes.get("Pattern"));
       readMethodRequestParameter(methodConfig, parameterName, description, nullable, defaultValue,
-          parameterTypes[i]);
+          parameterTypes[i], pattern);
     }
   }
 
   private void readMethodRequestParameter(ApiMethodConfig methodConfig, Annotation parameterName,
-      Annotation description, Annotation nullable, Annotation defaultValue, TypeToken<?> type)
+          Annotation description, Annotation nullable, Annotation defaultValue, TypeToken<?> type, Annotation pattern)
       throws IllegalArgumentException, SecurityException, IllegalAccessException, 
       InvocationTargetException, NoSuchMethodException {
     String parameterNameString = null;
@@ -395,10 +397,14 @@ public class ApiConfigAnnotationReader implements ApiConfigSource {
     if (defaultValue != null) {
       defaultValueString = getAnnotationProperty(defaultValue, "value");
     }
+    String patternString = null;
+    if (pattern != null) {
+      patternString = getAnnotationProperty(pattern, "regexp");
+    }
 
     ApiParameterConfig parameterConfig =
         methodConfig.addParameter(parameterNameString, descriptionString, nullable != null, 
-            defaultValueString, type);
+            defaultValueString, type, patternString);
 
     Annotation apiSerializer =
         type.getRawType().getAnnotation(annotationTypes.get("ApiTransformer"));

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/annotationreader/ApiConfigAnnotationReader.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/annotationreader/ApiConfigAnnotationReader.java
@@ -31,7 +31,7 @@ import com.google.api.server.spi.config.model.ApiConfig;
 import com.google.api.server.spi.config.model.ApiIssuerAudienceConfig;
 import com.google.api.server.spi.config.model.ApiIssuerConfigs;
 import com.google.api.server.spi.config.model.ApiMethodConfig;
-import com.google.api.server.spi.config.model.ApiParameterBoundaries;
+import com.google.api.server.spi.config.model.ApiValidationConstraints;
 import com.google.api.server.spi.config.model.ApiParameterConfig;
 import com.google.api.server.spi.config.model.ApiSerializationConfig;
 import com.google.common.collect.ImmutableList;
@@ -367,75 +367,55 @@ public class ApiConfigAnnotationReader implements ApiConfigSource {
     }
 
     for (int i = 0; i < parameterAnnotations.length; i++) {
-      Annotation parameterName =
-          AnnotationUtil.getNamedParameter(method, i, annotationTypes.get("Named"));
-      Annotation description =
-          AnnotationUtil.getParameterAnnotation(method, i, annotationTypes.get("Description"));
-      Annotation nullable =
-          AnnotationUtil.getNullableParameter(method, i, annotationTypes.get("Nullable"));
-      Annotation defaultValue =
-          AnnotationUtil.getParameterAnnotation(method, i, annotationTypes.get("DefaultValue"));
-      Annotation pattern =
-              AnnotationUtil.getParameterAnnotation(method, i, annotationTypes.get("Pattern"));
-      Annotation min =
-              AnnotationUtil.getParameterAnnotation(method, i, annotationTypes.get("Min"));
-      Annotation max =
-              AnnotationUtil.getParameterAnnotation(method, i, annotationTypes.get("Max"));
-      Annotation decimalMin =
-              AnnotationUtil.getParameterAnnotation(method, i, annotationTypes.get("DecimalMin"));
-      Annotation decimalMax =
-              AnnotationUtil.getParameterAnnotation(method, i, annotationTypes.get("DecimalMax"));
-      readMethodRequestParameter(methodConfig, parameterName, description, nullable, defaultValue,
-              parameterTypes[i], pattern, min, max, decimalMin, decimalMax);
+      ApiConfigAnnotations configAnnotations = new ApiConfigAnnotations(method, i, annotationTypes);
+      readMethodRequestParameter(methodConfig, parameterTypes[i], configAnnotations);
     }
   }
 
-  private void readMethodRequestParameter(ApiMethodConfig methodConfig, Annotation parameterName,
-          Annotation description, Annotation nullable, Annotation defaultValue, TypeToken<?> type,
-          Annotation pattern, Annotation min, Annotation max, Annotation decimalMin, Annotation decimalMax)
+  private void readMethodRequestParameter(ApiMethodConfig methodConfig, TypeToken<?> type, ApiConfigAnnotations annotations)
       throws IllegalArgumentException, SecurityException, IllegalAccessException, 
       InvocationTargetException, NoSuchMethodException {
     String parameterNameString = null;
-    if (parameterName != null) {
-      parameterNameString = getAnnotationProperty(parameterName, "value");
+    if (annotations.getParameterName() != null) {
+      parameterNameString = getAnnotationProperty(annotations.getParameterName(), "value");
     }
     String descriptionString = null;
-    if (description != null) {
-      descriptionString = getAnnotationProperty(description, "value");
+    if (annotations.getDescription() != null) {
+      descriptionString = getAnnotationProperty(annotations.getDescription(), "value");
     }
     String defaultValueString = null;
-    if (defaultValue != null) {
-      defaultValueString = getAnnotationProperty(defaultValue, "value");
+    if (annotations.getDefaultValue() != null) {
+      defaultValueString = getAnnotationProperty(annotations.getDefaultValue(), "value");
     }
     String patternString = null;
-    if (pattern != null) {
-      patternString = getAnnotationProperty(pattern, "regexp");
+    if (annotations.getPattern() != null) {
+      patternString = getAnnotationProperty(annotations.getPattern(), "regexp");
     }
     Long minLong = null;
-    if (min != null) {
-      minLong = getAnnotationProperty(min, "value");
+    if (annotations.getMin() != null) {
+      minLong = getAnnotationProperty(annotations.getMin(), "value");
     }
     Long maxLong = null;
-    if (max != null) {
-      maxLong = getAnnotationProperty(max, "value");
+    if (annotations.getMax() != null) {
+      maxLong = getAnnotationProperty(annotations.getMax(), "value");
     }
     String decimalMinString = null;
     Boolean decimalMinInclusive = null;
-    if (decimalMin != null) {
-      decimalMinString = getAnnotationProperty(decimalMin, "value");
-      decimalMinInclusive = getAnnotationProperty(decimalMin, "inclusive");
+    if (annotations.getDecimalMin() != null) {
+      decimalMinString = getAnnotationProperty(annotations.getDecimalMin(), "value");
+      decimalMinInclusive = getAnnotationProperty(annotations.getDecimalMin(), "inclusive");
     }
     String decimalMaxString = null;
     Boolean decimalMaxInclusive = null;
-    if (decimalMax != null) {
-      decimalMaxString = getAnnotationProperty(decimalMax, "value");
-      decimalMaxInclusive = getAnnotationProperty(decimalMax, "inclusive");
+    if (annotations.getDecimalMax() != null) {
+      decimalMaxString = getAnnotationProperty(annotations.getDecimalMax(), "value");
+      decimalMaxInclusive = getAnnotationProperty(annotations.getDecimalMax(), "inclusive");
     }
   
-    ApiParameterBoundaries boundaries = new ApiParameterBoundaries(minLong, maxLong, decimalMinString, decimalMaxString, decimalMinInclusive, decimalMaxInclusive);
+    ApiValidationConstraints validationConstraints = new ApiValidationConstraints(patternString, minLong, maxLong, decimalMinString, decimalMaxString, decimalMinInclusive, decimalMaxInclusive);
     ApiParameterConfig parameterConfig =
-        methodConfig.addParameter(parameterNameString, descriptionString, nullable != null, 
-            defaultValueString, type, patternString, boundaries);
+        methodConfig.addParameter(parameterNameString, descriptionString, annotations.getNullable() != null, 
+            defaultValueString, type, validationConstraints);
 
     Annotation apiSerializer =
         type.getRawType().getAnnotation(annotationTypes.get("ApiTransformer"));

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/annotationreader/ApiConfigAnnotationReader.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/annotationreader/ApiConfigAnnotationReader.java
@@ -420,15 +420,19 @@ public class ApiConfigAnnotationReader implements ApiConfigSource {
       maxLong = getAnnotationProperty(max, "value");
     }
     String decimalMinString = null;
+    Boolean decimalMinInclusive = null;
     if (decimalMin != null) {
       decimalMinString = getAnnotationProperty(decimalMin, "value");
+      decimalMinInclusive = getAnnotationProperty(decimalMin, "inclusive");
     }
     String decimalMaxString = null;
+    Boolean decimalMaxInclusive = null;
     if (decimalMax != null) {
       decimalMaxString = getAnnotationProperty(decimalMax, "value");
+      decimalMaxInclusive = getAnnotationProperty(decimalMax, "inclusive");
     }
   
-    ApiParameterBoundaries boundaries = new ApiParameterBoundaries(minLong, maxLong, decimalMinString, decimalMaxString);
+    ApiParameterBoundaries boundaries = new ApiParameterBoundaries(minLong, maxLong, decimalMinString, decimalMaxString, decimalMinInclusive, decimalMaxInclusive);
     ApiParameterConfig parameterConfig =
         methodConfig.addParameter(parameterNameString, descriptionString, nullable != null, 
             defaultValueString, type, patternString, boundaries);

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/annotationreader/ApiConfigAnnotations.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/annotationreader/ApiConfigAnnotations.java
@@ -1,0 +1,70 @@
+package com.google.api.server.spi.config.annotationreader;
+
+import static com.google.api.server.spi.config.annotationreader.AnnotationUtil.getNamedParameter;
+import static com.google.api.server.spi.config.annotationreader.AnnotationUtil.getNullableParameter;
+import static com.google.api.server.spi.config.annotationreader.AnnotationUtil.getParameterAnnotation;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+final class ApiConfigAnnotations {
+	
+	private Annotation parameterName;
+	private Annotation description;
+	private Annotation nullable;
+	private Annotation defaultValue;
+	private Annotation pattern;
+	private Annotation min;
+	private Annotation max;
+	private Annotation decimalMin;
+	private Annotation decimalMax;
+	
+	public ApiConfigAnnotations(Method method, int parameterIndex, Map<String, Class<? extends Annotation>> annotationTypes) {
+		this.parameterName = getNamedParameter(method, parameterIndex, annotationTypes.get("Named"));
+		this.description = getParameterAnnotation(method, parameterIndex, annotationTypes.get("Description"));
+		this.nullable = getNullableParameter(method, parameterIndex, annotationTypes.get("Nullable"));
+		this.defaultValue = getParameterAnnotation(method, parameterIndex, annotationTypes.get("DefaultValue"));
+		this.pattern = getParameterAnnotation(method, parameterIndex, annotationTypes.get("Pattern"));
+		this.min = getParameterAnnotation(method, parameterIndex, annotationTypes.get("Min"));
+		this.max = getParameterAnnotation(method, parameterIndex, annotationTypes.get("Max"));
+		this.decimalMin = getParameterAnnotation(method, parameterIndex, annotationTypes.get("DecimalMin"));
+		this.decimalMax = getParameterAnnotation(method, parameterIndex, annotationTypes.get("DecimalMax"));
+	}
+	
+	public Annotation getParameterName() {
+		return parameterName;
+	}
+	
+	public Annotation getDescription() {
+		return description;
+	}
+	
+	public Annotation getNullable() {
+		return nullable;
+	}
+	
+	public Annotation getDefaultValue() {
+		return defaultValue;
+	}
+	
+	public Annotation getPattern() {
+		return pattern;
+	}
+	
+	public Annotation getMin() {
+		return min;
+	}
+	
+	public Annotation getMax() {
+		return max;
+	}
+	
+	public Annotation getDecimalMin() {
+		return decimalMin;
+	}
+	
+	public Annotation getDecimalMax() {
+		return decimalMax;
+	}
+}

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiMethodConfig.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiMethodConfig.java
@@ -333,9 +333,9 @@ public class ApiMethodConfig {
    * it is non-optional and has no default.
    */
   public ApiParameterConfig addParameter(String name, String description, boolean nullable,
-		  String defaultValue, TypeToken<?> type, String pattern, ApiParameterBoundaries boundaries) {
+          String defaultValue, TypeToken<?> type, ApiValidationConstraints validationConstraints) {
     ApiParameterConfig config =
-        new ApiParameterConfig(this, name, description, nullable, defaultValue, type, typeLoader, pattern, boundaries);
+        new ApiParameterConfig(this, name, description, nullable, defaultValue, type, typeLoader, validationConstraints);
     parameterConfigs.add(config);
 
     if (config.getClassification() != Classification.INJECTED && name != null && !nullable

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiMethodConfig.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiMethodConfig.java
@@ -333,9 +333,9 @@ public class ApiMethodConfig {
    * it is non-optional and has no default.
    */
   public ApiParameterConfig addParameter(String name, String description, boolean nullable,
-          String defaultValue, TypeToken<?> type, String pattern) {
+		  String defaultValue, TypeToken<?> type, String pattern, ApiParameterBoundaries boundaries) {
     ApiParameterConfig config =
-        new ApiParameterConfig(this, name, description, nullable, defaultValue, type, typeLoader, pattern);
+        new ApiParameterConfig(this, name, description, nullable, defaultValue, type, typeLoader, pattern, boundaries);
     parameterConfigs.add(config);
 
     if (config.getClassification() != Classification.INJECTED && name != null && !nullable

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiMethodConfig.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiMethodConfig.java
@@ -333,9 +333,9 @@ public class ApiMethodConfig {
    * it is non-optional and has no default.
    */
   public ApiParameterConfig addParameter(String name, String description, boolean nullable,
-      String defaultValue, TypeToken<?> type) {
+          String defaultValue, TypeToken<?> type, String pattern) {
     ApiParameterConfig config =
-        new ApiParameterConfig(this, name, description, nullable, defaultValue, type, typeLoader);
+        new ApiParameterConfig(this, name, description, nullable, defaultValue, type, typeLoader, pattern);
     parameterConfigs.add(config);
 
     if (config.getClassification() != Classification.INJECTED && name != null && !nullable

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiParameterBoundaries.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiParameterBoundaries.java
@@ -3,21 +3,29 @@ package com.google.api.server.spi.config.model;
 import java.util.Objects;
 
 public class ApiParameterBoundaries {
+
 	private final Long min;
 	private final Long max;
-	
+
 	private final String decimalMin;
 	private final String decimalMax;
 	
-	public ApiParameterBoundaries(Long min, Long max, String decimalMin, String decimalMax) {
+	private final Boolean decimalMinInclusive;
+	private final Boolean decimalMaxInclusive;
+
+	public ApiParameterBoundaries(Long min, Long max, String decimalMin, String decimalMax, 
+			Boolean decimalMinInclusive, Boolean decimalMaxInclusive) {
 		this.min = min;
 		this.max = max;
 		this.decimalMin = decimalMin;
 		this.decimalMax = decimalMax;
+		this.decimalMinInclusive = decimalMinInclusive;
+		this.decimalMaxInclusive = decimalMaxInclusive;
 	}
 	
 	public ApiParameterBoundaries(ApiParameterBoundaries original) {
-		this(original.min, original.max, original.decimalMin, original.decimalMax);
+		this(original.min, original.max, original.decimalMin, original.decimalMax, 
+				original.decimalMinInclusive, original.decimalMaxInclusive);
 	}
 	
 	public Long getMin() {
@@ -36,6 +44,14 @@ public class ApiParameterBoundaries {
 		return decimalMax;
 	}
 	
+	public Boolean getDecimalMinInclusive() {
+		return decimalMinInclusive;
+	}
+	
+	public Boolean getDecimalMaxInclusive() {
+		return decimalMaxInclusive;
+	}
+	
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) {
@@ -45,11 +61,11 @@ public class ApiParameterBoundaries {
 			return false;
 		}
 		ApiParameterBoundaries that = (ApiParameterBoundaries) o;
-		return min.equals(that.min) && max.equals(that.max) && decimalMin.equals(that.decimalMin) && decimalMax.equals(that.decimalMax);
+		return Objects.equals(min, that.min) && Objects.equals(max, that.max) && Objects.equals(decimalMin, that.decimalMin) && Objects.equals(decimalMax, that.decimalMax) && Objects.equals(decimalMinInclusive, that.decimalMinInclusive) && Objects.equals(decimalMaxInclusive, that.decimalMaxInclusive);
 	}
 	
 	@Override
 	public int hashCode() {
-		return Objects.hash(min, max, decimalMin, decimalMax);
+		return Objects.hash(min, max, decimalMin, decimalMax, decimalMinInclusive, decimalMaxInclusive);
 	}
 }

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiParameterBoundaries.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiParameterBoundaries.java
@@ -1,0 +1,55 @@
+package com.google.api.server.spi.config.model;
+
+import java.util.Objects;
+
+public class ApiParameterBoundaries {
+	private final Long min;
+	private final Long max;
+	
+	private final String decimalMin;
+	private final String decimalMax;
+	
+	public ApiParameterBoundaries(Long min, Long max, String decimalMin, String decimalMax) {
+		this.min = min;
+		this.max = max;
+		this.decimalMin = decimalMin;
+		this.decimalMax = decimalMax;
+	}
+	
+	public ApiParameterBoundaries(ApiParameterBoundaries original) {
+		this(original.min, original.max, original.decimalMin, original.decimalMax);
+	}
+	
+	public Long getMin() {
+		return min;
+	}
+	
+	public Long getMax() {
+		return max;
+	}
+	
+	public String getDecimalMin() {
+		return decimalMin;
+	}
+	
+	public String getDecimalMax() {
+		return decimalMax;
+	}
+	
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		ApiParameterBoundaries that = (ApiParameterBoundaries) o;
+		return min.equals(that.min) && max.equals(that.max) && decimalMin.equals(that.decimalMin) && decimalMax.equals(that.decimalMax);
+	}
+	
+	@Override
+	public int hashCode() {
+		return Objects.hash(min, max, decimalMin, decimalMax);
+	}
+}

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiParameterConfig.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiParameterConfig.java
@@ -35,8 +35,7 @@ public class ApiParameterConfig {
   private final boolean nullable;
   private final String defaultValue;
   private final TypeToken<?> type;
-  private final String pattern;
-  private final ApiParameterBoundaries boundaries;
+  private final ApiValidationConstraints validationConstraints;
 
   private Class<? extends Transformer<?, ?>> serializer;
   private Class<? extends Transformer<?, ?>> repeatedItemSerializer;
@@ -60,8 +59,8 @@ public class ApiParameterConfig {
   }
 
   public ApiParameterConfig(ApiMethodConfig apiMethodConfig, String name, String description,
-          boolean nullable, String defaultValue, TypeToken<?> type, TypeLoader typeLoader, 
-          String pattern, ApiParameterBoundaries boundaries) {
+          boolean nullable, String defaultValue, TypeToken<?> type, TypeLoader typeLoader,
+          ApiValidationConstraints validationConstraints) {
     this.apiMethodConfig = apiMethodConfig;
     this.name = name;
     this.description = description;
@@ -71,8 +70,7 @@ public class ApiParameterConfig {
     this.serializer = null;
     this.repeatedItemSerializer = null;
     this.typeLoader = typeLoader;
-    this.pattern = pattern;
-    this.boundaries = boundaries;
+    this.validationConstraints = validationConstraints;
   }
 
   public ApiParameterConfig(ApiParameterConfig original, ApiMethodConfig apiMethodConfig) {
@@ -85,8 +83,7 @@ public class ApiParameterConfig {
     this.serializer = original.serializer;
     this.repeatedItemSerializer = original.repeatedItemSerializer;
     this.typeLoader = original.typeLoader;
-    this.pattern = original.pattern;
-    this.boundaries = new ApiParameterBoundaries(original.boundaries);
+    this.validationConstraints = new ApiValidationConstraints(original.validationConstraints);
   }
 
   @Override
@@ -102,8 +99,7 @@ public class ApiParameterConfig {
           && Objects.equals(serializer, parameter.serializer)
           && Objects.equals(repeatedItemSerializer, parameter.repeatedItemSerializer)
           && Objects.equals(typeLoader, parameter.typeLoader)
-          && Objects.equals(pattern, parameter.pattern)
-          && Objects.equals(boundaries, parameter.boundaries);
+          && Objects.equals(validationConstraints, parameter.validationConstraints);
     } else {
       return false;
     }
@@ -112,7 +108,7 @@ public class ApiParameterConfig {
   @Override
   public int hashCode() {
     return Objects.hash(name, nullable, defaultValue, type, serializer, repeatedItemSerializer,
-        typeLoader, pattern, boundaries);
+        typeLoader, validationConstraints);
   }
 
   public ApiMethodConfig getApiMethodConfig() {
@@ -139,12 +135,8 @@ public class ApiParameterConfig {
     return type;
   }
 
-  public String getPattern() {
-    return pattern;
-  }
-
-  public ApiParameterBoundaries getBoundaries() {
-    return boundaries;
+  public ApiValidationConstraints getValidationConstraints() {
+    return validationConstraints;
   }
 
   /**

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiParameterConfig.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiParameterConfig.java
@@ -35,6 +35,7 @@ public class ApiParameterConfig {
   private final boolean nullable;
   private final String defaultValue;
   private final TypeToken<?> type;
+  private final String pattern;
 
   private Class<? extends Transformer<?, ?>> serializer;
   private Class<? extends Transformer<?, ?>> repeatedItemSerializer;
@@ -58,7 +59,7 @@ public class ApiParameterConfig {
   }
 
   public ApiParameterConfig(ApiMethodConfig apiMethodConfig, String name, String description,
-      boolean nullable, String defaultValue, TypeToken<?> type, TypeLoader typeLoader) {
+          boolean nullable, String defaultValue, TypeToken<?> type, TypeLoader typeLoader, String pattern) {
     this.apiMethodConfig = apiMethodConfig;
     this.name = name;
     this.description = description;
@@ -68,6 +69,7 @@ public class ApiParameterConfig {
     this.serializer = null;
     this.repeatedItemSerializer = null;
     this.typeLoader = typeLoader;
+    this.pattern = pattern;
   }
 
   public ApiParameterConfig(ApiParameterConfig original, ApiMethodConfig apiMethodConfig) {
@@ -80,6 +82,7 @@ public class ApiParameterConfig {
     this.serializer = original.serializer;
     this.repeatedItemSerializer = original.repeatedItemSerializer;
     this.typeLoader = original.typeLoader;
+    this.pattern = original.pattern;
   }
 
   @Override
@@ -94,7 +97,8 @@ public class ApiParameterConfig {
           && Objects.equals(type, parameter.type)
           && Objects.equals(serializer, parameter.serializer)
           && Objects.equals(repeatedItemSerializer, parameter.repeatedItemSerializer)
-          && Objects.equals(typeLoader, parameter.typeLoader);
+          && Objects.equals(typeLoader, parameter.typeLoader)
+          && Objects.equals(pattern, parameter.pattern);
     } else {
       return false;
     }
@@ -103,7 +107,7 @@ public class ApiParameterConfig {
   @Override
   public int hashCode() {
     return Objects.hash(name, nullable, defaultValue, type, serializer, repeatedItemSerializer,
-        typeLoader);
+        typeLoader, pattern);
   }
 
   public ApiMethodConfig getApiMethodConfig() {
@@ -129,7 +133,11 @@ public class ApiParameterConfig {
   public TypeToken<?> getType() {
     return type;
   }
-
+  
+  public String getPattern() {
+    return pattern;
+  }
+  
   /**
    * If the serialized type of the parameter is a repeated type, returns the individual item type.
    * Otherwise returns {@code null}.

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiParameterConfig.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiParameterConfig.java
@@ -36,6 +36,7 @@ public class ApiParameterConfig {
   private final String defaultValue;
   private final TypeToken<?> type;
   private final String pattern;
+  private final ApiParameterBoundaries boundaries;
 
   private Class<? extends Transformer<?, ?>> serializer;
   private Class<? extends Transformer<?, ?>> repeatedItemSerializer;
@@ -59,7 +60,8 @@ public class ApiParameterConfig {
   }
 
   public ApiParameterConfig(ApiMethodConfig apiMethodConfig, String name, String description,
-          boolean nullable, String defaultValue, TypeToken<?> type, TypeLoader typeLoader, String pattern) {
+          boolean nullable, String defaultValue, TypeToken<?> type, TypeLoader typeLoader, 
+          String pattern, ApiParameterBoundaries boundaries) {
     this.apiMethodConfig = apiMethodConfig;
     this.name = name;
     this.description = description;
@@ -70,6 +72,7 @@ public class ApiParameterConfig {
     this.repeatedItemSerializer = null;
     this.typeLoader = typeLoader;
     this.pattern = pattern;
+    this.boundaries = boundaries;
   }
 
   public ApiParameterConfig(ApiParameterConfig original, ApiMethodConfig apiMethodConfig) {
@@ -83,6 +86,7 @@ public class ApiParameterConfig {
     this.repeatedItemSerializer = original.repeatedItemSerializer;
     this.typeLoader = original.typeLoader;
     this.pattern = original.pattern;
+    this.boundaries = new ApiParameterBoundaries(original.boundaries);
   }
 
   @Override
@@ -98,7 +102,8 @@ public class ApiParameterConfig {
           && Objects.equals(serializer, parameter.serializer)
           && Objects.equals(repeatedItemSerializer, parameter.repeatedItemSerializer)
           && Objects.equals(typeLoader, parameter.typeLoader)
-          && Objects.equals(pattern, parameter.pattern);
+          && Objects.equals(pattern, parameter.pattern)
+          && Objects.equals(boundaries, parameter.boundaries);
     } else {
       return false;
     }
@@ -107,7 +112,7 @@ public class ApiParameterConfig {
   @Override
   public int hashCode() {
     return Objects.hash(name, nullable, defaultValue, type, serializer, repeatedItemSerializer,
-        typeLoader, pattern);
+        typeLoader, pattern, boundaries);
   }
 
   public ApiMethodConfig getApiMethodConfig() {
@@ -133,11 +138,15 @@ public class ApiParameterConfig {
   public TypeToken<?> getType() {
     return type;
   }
-  
+
   public String getPattern() {
     return pattern;
   }
-  
+
+  public ApiParameterBoundaries getBoundaries() {
+    return boundaries;
+  }
+
   /**
    * If the serialized type of the parameter is a repeated type, returns the individual item type.
    * Otherwise returns {@code null}.

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiValidationConstraints.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiValidationConstraints.java
@@ -2,19 +2,22 @@ package com.google.api.server.spi.config.model;
 
 import java.util.Objects;
 
-public class ApiParameterBoundaries {
-
+public class ApiValidationConstraints {
+	
+	private final String pattern;
+	
 	private final Long min;
 	private final Long max;
-
+	
 	private final String decimalMin;
 	private final String decimalMax;
 	
 	private final Boolean decimalMinInclusive;
 	private final Boolean decimalMaxInclusive;
 
-	public ApiParameterBoundaries(Long min, Long max, String decimalMin, String decimalMax, 
+	public ApiValidationConstraints(String pattern, Long min, Long max, String decimalMin, String decimalMax,
 			Boolean decimalMinInclusive, Boolean decimalMaxInclusive) {
+		this.pattern = pattern;
 		this.min = min;
 		this.max = max;
 		this.decimalMin = decimalMin;
@@ -23,9 +26,13 @@ public class ApiParameterBoundaries {
 		this.decimalMaxInclusive = decimalMaxInclusive;
 	}
 	
-	public ApiParameterBoundaries(ApiParameterBoundaries original) {
-		this(original.min, original.max, original.decimalMin, original.decimalMax, 
+	public ApiValidationConstraints(ApiValidationConstraints original) {
+		this(original.pattern, original.min, original.max, original.decimalMin, original.decimalMax, 
 				original.decimalMinInclusive, original.decimalMaxInclusive);
+	}
+	
+	public String getPattern() {
+		return pattern;
 	}
 	
 	public Long getMin() {
@@ -60,12 +67,12 @@ public class ApiParameterBoundaries {
 		if (o == null || getClass() != o.getClass()) {
 			return false;
 		}
-		ApiParameterBoundaries that = (ApiParameterBoundaries) o;
-		return Objects.equals(min, that.min) && Objects.equals(max, that.max) && Objects.equals(decimalMin, that.decimalMin) && Objects.equals(decimalMax, that.decimalMax) && Objects.equals(decimalMinInclusive, that.decimalMinInclusive) && Objects.equals(decimalMaxInclusive, that.decimalMaxInclusive);
+		ApiValidationConstraints that = (ApiValidationConstraints) o;
+		return Objects.equals(pattern, that.pattern) && Objects.equals(min, that.min) && Objects.equals(max, that.max) && Objects.equals(decimalMin, that.decimalMin) && Objects.equals(decimalMax, that.decimalMax) && Objects.equals(decimalMinInclusive, that.decimalMinInclusive) && Objects.equals(decimalMaxInclusive, that.decimalMaxInclusive);
 	}
 	
 	@Override
 	public int hashCode() {
-		return Objects.hash(min, max, decimalMin, decimalMax, decimalMinInclusive, decimalMaxInclusive);
+		return Objects.hash(pattern, min, max, decimalMin, decimalMax, decimalMinInclusive, decimalMaxInclusive);
 	}
 }

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/discovery/DiscoveryGenerator.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/discovery/DiscoveryGenerator.java
@@ -410,6 +410,18 @@ public class DiscoveryGenerator {
     if (parameterConfig.getPattern() != null) {
       schema.setPattern(parameterConfig.getPattern());
     }
+    if (parameterConfig.getBoundaries() != null) {
+      if (parameterConfig.getBoundaries().getDecimalMin() != null) {
+        schema.setMinimum(parameterConfig.getBoundaries().getDecimalMin());
+      } else if (parameterConfig.getBoundaries().getMin() != null) {
+        schema.setMinimum(parameterConfig.getBoundaries().getMin().toString());
+      }
+      if (parameterConfig.getBoundaries().getDecimalMax() != null) {
+        schema.setMaximum(parameterConfig.getBoundaries().getDecimalMax());
+      } else if (parameterConfig.getBoundaries().getMax() != null) {
+        schema.setMaximum(parameterConfig.getBoundaries().getMax().toString());
+      }
+    }
     return schema;
   }
 

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/discovery/DiscoveryGenerator.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/discovery/DiscoveryGenerator.java
@@ -407,6 +407,9 @@ public class DiscoveryGenerator {
     if (parameterConfig.getDescription() != null) {
       schema.setDescription(parameterConfig.getDescription());
     }
+    if (parameterConfig.getPattern() != null) {
+      schema.setPattern(parameterConfig.getPattern());
+    }
     return schema;
   }
 

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/discovery/UNSUPPORTED_FEATURES.md
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/discovery/UNSUPPORTED_FEATURES.md
@@ -1,2 +1,2 @@
 - Models:
-  - minimum,maximum,pattern,readonly,annotations
+  - readonly,annotations

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/SwaggerGenerator.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/SwaggerGenerator.java
@@ -481,24 +481,25 @@ public class SwaggerGenerator {
           if (!Strings.isEmptyOrWhitespace(defaultValue)) {
             parameter.setDefaultValue(defaultValue);
           }
-          String pattern = parameterConfig.getPattern();
-          if (!Strings.isEmptyOrWhitespace(pattern)) {
-            parameter.setPattern(pattern);
-          }
-          if (parameterConfig.getBoundaries() != null) {
-            if (parameterConfig.getBoundaries().getDecimalMin() != null) {
-              parameter.setMinimum(new BigDecimal(parameterConfig.getBoundaries().getDecimalMin()));
-              parameter.setExclusiveMinimum(!parameterConfig.getBoundaries().getDecimalMinInclusive());
-            } else if (parameterConfig.getBoundaries().getMin() != null) {
-              parameter.setMinimum(new BigDecimal(parameterConfig.getBoundaries().getMin()));
+          Optional.ofNullable(parameterConfig.getValidationConstraints()).ifPresent(constraints -> {
+            String pattern = constraints.getPattern();
+            if (!Strings.isEmptyOrWhitespace(pattern)) {
+              parameter.setPattern(pattern);
             }
-            if (parameterConfig.getBoundaries().getDecimalMax() != null) {
-              parameter.setMaximum(new BigDecimal(parameterConfig.getBoundaries().getDecimalMax()));
-              parameter.setExclusiveMaximum(!parameterConfig.getBoundaries().getDecimalMaxInclusive());
-            } else if (parameterConfig.getBoundaries().getMax() != null) {
-              parameter.setMaximum(new BigDecimal(parameterConfig.getBoundaries().getMax()));
+            // DecimalMin/Max annotations take precedence over Min/Max
+            if (constraints.getDecimalMin() != null) {
+              parameter.setMinimum(new BigDecimal(constraints.getDecimalMin()));
+              parameter.setExclusiveMinimum(!constraints.getDecimalMinInclusive());
+            } else if (constraints.getMin() != null) {
+              parameter.setMinimum(new BigDecimal(constraints.getMin()));
             }
-          }
+            if (constraints.getDecimalMax() != null) {
+              parameter.setMaximum(new BigDecimal(constraints.getDecimalMax()));
+              parameter.setExclusiveMaximum(!constraints.getDecimalMaxInclusive());
+            } else if (constraints.getMax() != null) {
+              parameter.setMaximum(new BigDecimal(constraints.getMax()));
+            }
+          });
           boolean required = isPathParameter || (!parameterConfig.getNullable()
               && defaultValue == null);
           if (parameterConfig.isRepeated()) {

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/SwaggerGenerator.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/SwaggerGenerator.java
@@ -480,6 +480,10 @@ public class SwaggerGenerator {
           if (!Strings.isEmptyOrWhitespace(defaultValue)) {
             parameter.setDefaultValue(defaultValue);
           }
+          String pattern = parameterConfig.getPattern();
+          if (!Strings.isEmptyOrWhitespace(pattern)) {
+            parameter.setPattern(pattern);
+          }
           boolean required = isPathParameter || (!parameterConfig.getNullable()
               && defaultValue == null);
           if (parameterConfig.isRepeated()) {

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/SwaggerGenerator.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/SwaggerGenerator.java
@@ -488,11 +488,13 @@ public class SwaggerGenerator {
           if (parameterConfig.getBoundaries() != null) {
             if (parameterConfig.getBoundaries().getDecimalMin() != null) {
               parameter.setMinimum(new BigDecimal(parameterConfig.getBoundaries().getDecimalMin()));
+              parameter.setExclusiveMinimum(!parameterConfig.getBoundaries().getDecimalMinInclusive());
             } else if (parameterConfig.getBoundaries().getMin() != null) {
               parameter.setMinimum(new BigDecimal(parameterConfig.getBoundaries().getMin()));
             }
             if (parameterConfig.getBoundaries().getDecimalMax() != null) {
               parameter.setMaximum(new BigDecimal(parameterConfig.getBoundaries().getDecimalMax()));
+              parameter.setExclusiveMaximum(!parameterConfig.getBoundaries().getDecimalMaxInclusive());
             } else if (parameterConfig.getBoundaries().getMax() != null) {
               parameter.setMaximum(new BigDecimal(parameterConfig.getBoundaries().getMax()));
             }

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/SwaggerGenerator.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/SwaggerGenerator.java
@@ -99,6 +99,7 @@ import io.swagger.models.properties.RefProperty;
 import io.swagger.models.properties.StringProperty;
 import io.swagger.models.refs.RefType;
 import java.lang.reflect.Type;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -483,6 +484,18 @@ public class SwaggerGenerator {
           String pattern = parameterConfig.getPattern();
           if (!Strings.isEmptyOrWhitespace(pattern)) {
             parameter.setPattern(pattern);
+          }
+          if (parameterConfig.getBoundaries() != null) {
+            if (parameterConfig.getBoundaries().getDecimalMin() != null) {
+              parameter.setMinimum(new BigDecimal(parameterConfig.getBoundaries().getDecimalMin()));
+            } else if (parameterConfig.getBoundaries().getMin() != null) {
+              parameter.setMinimum(new BigDecimal(parameterConfig.getBoundaries().getMin()));
+            }
+            if (parameterConfig.getBoundaries().getDecimalMax() != null) {
+              parameter.setMaximum(new BigDecimal(parameterConfig.getBoundaries().getDecimalMax()));
+            } else if (parameterConfig.getBoundaries().getMax() != null) {
+              parameter.setMaximum(new BigDecimal(parameterConfig.getBoundaries().getMax()));
+            }
           }
           boolean required = isPathParameter || (!parameterConfig.getNullable()
               && defaultValue == null);

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/UNSUPPORTED_FEATURES.md
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/UNSUPPORTED_FEATURES.md
@@ -3,7 +3,6 @@
 - Paths
   - Configurable tag content and format
 - Parameters
-  - range for ints (minimum, maximum)
   - cardinality (minItems, maxItems)
   - other repeated param features (uniqueItems, default values)
   - empty value parameters

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/config/annotationreader/ApiMethodAnnotationConfigTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/config/annotationreader/ApiMethodAnnotationConfigTest.java
@@ -28,6 +28,7 @@ import com.google.api.server.spi.config.model.ApiClassConfig;
 import com.google.api.server.spi.config.model.ApiConfig;
 import com.google.api.server.spi.config.model.ApiMethodConfig;
 import com.google.api.server.spi.config.model.ApiSerializationConfig;
+import com.google.api.server.spi.config.model.ApiValidationConstraints;
 import com.google.api.server.spi.config.scope.AuthScopeExpression;
 import com.google.api.server.spi.config.scope.AuthScopeExpressions;
 import com.google.api.server.spi.testing.PassAuthenticator;
@@ -103,7 +104,8 @@ public class ApiMethodAnnotationConfigTest {
   public void testAddParameter() {
     assertEquals(0, config.getParameterConfigs().size());
 
-    config.addParameter("bleh", "desc", false, null, TypeToken.of(String.class), "\\d{2}", null);
+    ApiValidationConstraints validationConstraints = new ApiValidationConstraints("\\d{2}", 1L, 2L, "3.0", "4.0", true, false);
+    config.addParameter("bleh", "desc", false, null, TypeToken.of(String.class), validationConstraints);
 
     assertEquals(1, config.getParameterConfigs().size());
     assertEquals("bleh", config.getParameterConfigs().get(0).getName());
@@ -113,19 +115,26 @@ public class ApiMethodAnnotationConfigTest {
     assertEquals(
         TypeToken.of(String.class), config.getParameterConfigs().get(0).getSchemaBaseType());
     assertEquals("overrideMethod1/{bleh}", config.getPath());
-    assertEquals("\\d{2}", config.getParameterConfigs().get(0).getPattern());
+    ApiValidationConstraints actualValidationConstraints = config.getParameterConfigs().get(0).getValidationConstraints();
+    assertEquals("\\d{2}", actualValidationConstraints.getPattern());
+    assertEquals(new Long(1L), actualValidationConstraints.getMin());
+    assertEquals(new Long(2L), actualValidationConstraints.getMax());
+    assertEquals("3.0", actualValidationConstraints.getDecimalMin());
+    assertEquals("4.0", actualValidationConstraints.getDecimalMax());
+    assertEquals(Boolean.TRUE, actualValidationConstraints.getDecimalMinInclusive());
+    assertEquals(Boolean.FALSE, actualValidationConstraints.getDecimalMaxInclusive());
   }
 
   @Test
   public void testAddParameter_nullableOrDefault() {
     assertEquals(0, config.getParameterConfigs().size());
 
-    config.addParameter("bleh", null, true, null, TypeToken.of(String.class), null, null);
+    config.addParameter("bleh", null, true, null, TypeToken.of(String.class), null);
     assertEquals(1, config.getParameterConfigs().size());
     assertEquals("bleh", config.getParameterConfigs().get(0).getName());
     assertEquals("overrideMethod1", config.getPath());
 
-    config.addParameter("foo", null, false, "42", TypeToken.of(String.class), null, null);
+    config.addParameter("foo", null, false, "42", TypeToken.of(String.class), null);
     assertEquals(2, config.getParameterConfigs().size());
     assertEquals("foo", config.getParameterConfigs().get(1).getName());
     assertEquals("overrideMethod1", config.getPath());

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/config/annotationreader/ApiMethodAnnotationConfigTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/config/annotationreader/ApiMethodAnnotationConfigTest.java
@@ -103,7 +103,7 @@ public class ApiMethodAnnotationConfigTest {
   public void testAddParameter() {
     assertEquals(0, config.getParameterConfigs().size());
 
-    config.addParameter("bleh", "desc", false, null, TypeToken.of(String.class), "\\d{2}");
+    config.addParameter("bleh", "desc", false, null, TypeToken.of(String.class), "\\d{2}", null);
 
     assertEquals(1, config.getParameterConfigs().size());
     assertEquals("bleh", config.getParameterConfigs().get(0).getName());
@@ -120,12 +120,12 @@ public class ApiMethodAnnotationConfigTest {
   public void testAddParameter_nullableOrDefault() {
     assertEquals(0, config.getParameterConfigs().size());
 
-    config.addParameter("bleh", null, true, null, TypeToken.of(String.class), null);
+    config.addParameter("bleh", null, true, null, TypeToken.of(String.class), null, null);
     assertEquals(1, config.getParameterConfigs().size());
     assertEquals("bleh", config.getParameterConfigs().get(0).getName());
     assertEquals("overrideMethod1", config.getPath());
 
-    config.addParameter("foo", null, false, "42", TypeToken.of(String.class), null);
+    config.addParameter("foo", null, false, "42", TypeToken.of(String.class), null, null);
     assertEquals(2, config.getParameterConfigs().size());
     assertEquals("foo", config.getParameterConfigs().get(1).getName());
     assertEquals("overrideMethod1", config.getPath());

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/config/annotationreader/ApiMethodAnnotationConfigTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/config/annotationreader/ApiMethodAnnotationConfigTest.java
@@ -103,7 +103,7 @@ public class ApiMethodAnnotationConfigTest {
   public void testAddParameter() {
     assertEquals(0, config.getParameterConfigs().size());
 
-    config.addParameter("bleh", "desc", false, null, TypeToken.of(String.class));
+    config.addParameter("bleh", "desc", false, null, TypeToken.of(String.class), "\\d{2}");
 
     assertEquals(1, config.getParameterConfigs().size());
     assertEquals("bleh", config.getParameterConfigs().get(0).getName());
@@ -113,18 +113,19 @@ public class ApiMethodAnnotationConfigTest {
     assertEquals(
         TypeToken.of(String.class), config.getParameterConfigs().get(0).getSchemaBaseType());
     assertEquals("overrideMethod1/{bleh}", config.getPath());
+    assertEquals("\\d{2}", config.getParameterConfigs().get(0).getPattern());
   }
 
   @Test
   public void testAddParameter_nullableOrDefault() {
     assertEquals(0, config.getParameterConfigs().size());
 
-    config.addParameter("bleh", null, true, null, TypeToken.of(String.class));
+    config.addParameter("bleh", null, true, null, TypeToken.of(String.class), null);
     assertEquals(1, config.getParameterConfigs().size());
     assertEquals("bleh", config.getParameterConfigs().get(0).getName());
     assertEquals("overrideMethod1", config.getPath());
 
-    config.addParameter("foo", null, false, "42", TypeToken.of(String.class));
+    config.addParameter("foo", null, false, "42", TypeToken.of(String.class), null);
     assertEquals(2, config.getParameterConfigs().size());
     assertEquals("foo", config.getParameterConfigs().get(1).getName());
     assertEquals("overrideMethod1", config.getPath());

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/config/model/ApiMethodConfigTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/config/model/ApiMethodConfigTest.java
@@ -128,20 +128,20 @@ public class ApiMethodConfigTest {
 
   @Test
   public void addInjectedParameter_notInPath() {
-    methodConfig.addParameter("alt", null, false, null, TypeToken.of(String.class));
+    methodConfig.addParameter("alt", null, false, null, TypeToken.of(String.class), null);
     assertThat(methodConfig.getPath()).doesNotContain("{alt}");
   }
 
   @Test
   public void addPathParameter_appendsToCanonicalPath() {
-    methodConfig.addParameter("test", null, false, null, TypeToken.of(String.class));
+    methodConfig.addParameter("test", null, false, null, TypeToken.of(String.class), null);
     assertThat(methodConfig.getCanonicalPath()).contains("{test}");
   }
 
   @Test
   public void addPathParameter_doesNotAppendIfInPathAlready() {
     methodConfig.setPath("test/{test}");
-    methodConfig.addParameter("test", null, false, null, TypeToken.of(String.class));
+    methodConfig.addParameter("test", null, false, null, TypeToken.of(String.class), null);
     assertThat(methodConfig.getPath()).isEqualTo("test/{test}");
   }
 }

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/config/model/ApiMethodConfigTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/config/model/ApiMethodConfigTest.java
@@ -128,20 +128,20 @@ public class ApiMethodConfigTest {
 
   @Test
   public void addInjectedParameter_notInPath() {
-    methodConfig.addParameter("alt", null, false, null, TypeToken.of(String.class), null, null);
+    methodConfig.addParameter("alt", null, false, null, TypeToken.of(String.class), null);
     assertThat(methodConfig.getPath()).doesNotContain("{alt}");
   }
 
   @Test
   public void addPathParameter_appendsToCanonicalPath() {
-    methodConfig.addParameter("test", null, false, null, TypeToken.of(String.class), null, null);
+    methodConfig.addParameter("test", null, false, null, TypeToken.of(String.class), null);
     assertThat(methodConfig.getCanonicalPath()).contains("{test}");
   }
 
   @Test
   public void addPathParameter_doesNotAppendIfInPathAlready() {
     methodConfig.setPath("test/{test}");
-    methodConfig.addParameter("test", null, false, null, TypeToken.of(String.class), null, null);
+    methodConfig.addParameter("test", null, false, null, TypeToken.of(String.class), null);
     assertThat(methodConfig.getPath()).isEqualTo("test/{test}");
   }
 }

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/config/model/ApiMethodConfigTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/config/model/ApiMethodConfigTest.java
@@ -128,20 +128,20 @@ public class ApiMethodConfigTest {
 
   @Test
   public void addInjectedParameter_notInPath() {
-    methodConfig.addParameter("alt", null, false, null, TypeToken.of(String.class), null);
+    methodConfig.addParameter("alt", null, false, null, TypeToken.of(String.class), null, null);
     assertThat(methodConfig.getPath()).doesNotContain("{alt}");
   }
 
   @Test
   public void addPathParameter_appendsToCanonicalPath() {
-    methodConfig.addParameter("test", null, false, null, TypeToken.of(String.class), null);
+    methodConfig.addParameter("test", null, false, null, TypeToken.of(String.class), null, null);
     assertThat(methodConfig.getCanonicalPath()).contains("{test}");
   }
 
   @Test
   public void addPathParameter_doesNotAppendIfInPathAlready() {
     methodConfig.setPath("test/{test}");
-    methodConfig.addParameter("test", null, false, null, TypeToken.of(String.class), null);
+    methodConfig.addParameter("test", null, false, null, TypeToken.of(String.class), null, null);
     assertThat(methodConfig.getPath()).isEqualTo("test/{test}");
   }
 }

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/config/model/ApiParameterConfigTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/config/model/ApiParameterConfigTest.java
@@ -87,9 +87,9 @@ public class ApiParameterConfigTest {
     Mockito.when(apiConfig.getSerializationConfig()).thenReturn(serializationConfig);
 
     config = new ApiParameterConfig(
-        apiMethodConfig, "bleh", null, false, null, TypeToken.of(String.class), typeLoader);
+        apiMethodConfig, "bleh", null, false, null, TypeToken.of(String.class), typeLoader, null);
     configWithArray = new ApiParameterConfig(
-        apiMethodConfig, "bleh", null, false, null, TypeToken.of(Boolean[].class), typeLoader);
+        apiMethodConfig, "bleh", null, false, null, TypeToken.of(Boolean[].class), typeLoader, null);
   }
 
   @Test
@@ -157,6 +157,6 @@ public class ApiParameterConfigTest {
 
   private ApiParameterConfig createStandardParameter(String name) {
     return new ApiParameterConfig(
-        apiMethodConfig, "alt", null, false, null, TypeToken.of(String.class), typeLoader);
+        apiMethodConfig, "alt", null, false, null, TypeToken.of(String.class), typeLoader, null);
   }
 }

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/config/model/ApiParameterConfigTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/config/model/ApiParameterConfigTest.java
@@ -87,9 +87,9 @@ public class ApiParameterConfigTest {
     Mockito.when(apiConfig.getSerializationConfig()).thenReturn(serializationConfig);
 
     config = new ApiParameterConfig(
-        apiMethodConfig, "bleh", null, false, null, TypeToken.of(String.class), typeLoader, null, null);
+        apiMethodConfig, "bleh", null, false, null, TypeToken.of(String.class), typeLoader, null);
     configWithArray = new ApiParameterConfig(
-        apiMethodConfig, "bleh", null, false, null, TypeToken.of(Boolean[].class), typeLoader, null, null);
+        apiMethodConfig, "bleh", null, false, null, TypeToken.of(Boolean[].class), typeLoader, null);
   }
 
   @Test
@@ -157,6 +157,6 @@ public class ApiParameterConfigTest {
 
   private ApiParameterConfig createStandardParameter(String name) {
     return new ApiParameterConfig(
-        apiMethodConfig, "alt", null, false, null, TypeToken.of(String.class), typeLoader, null, null);
+        apiMethodConfig, "alt", null, false, null, TypeToken.of(String.class), typeLoader, null);
   }
 }

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/config/model/ApiParameterConfigTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/config/model/ApiParameterConfigTest.java
@@ -87,9 +87,9 @@ public class ApiParameterConfigTest {
     Mockito.when(apiConfig.getSerializationConfig()).thenReturn(serializationConfig);
 
     config = new ApiParameterConfig(
-        apiMethodConfig, "bleh", null, false, null, TypeToken.of(String.class), typeLoader, null);
+        apiMethodConfig, "bleh", null, false, null, TypeToken.of(String.class), typeLoader, null, null);
     configWithArray = new ApiParameterConfig(
-        apiMethodConfig, "bleh", null, false, null, TypeToken.of(Boolean[].class), typeLoader, null);
+        apiMethodConfig, "bleh", null, false, null, TypeToken.of(Boolean[].class), typeLoader, null, null);
   }
 
   @Test
@@ -157,6 +157,6 @@ public class ApiParameterConfigTest {
 
   private ApiParameterConfig createStandardParameter(String name) {
     return new ApiParameterConfig(
-        apiMethodConfig, "alt", null, false, null, TypeToken.of(String.class), typeLoader, null);
+        apiMethodConfig, "alt", null, false, null, TypeToken.of(String.class), typeLoader, null, null);
   }
 }

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/config/validation/ApiConfigValidatorTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/config/validation/ApiConfigValidatorTest.java
@@ -207,7 +207,7 @@ public class ApiConfigValidatorTest {
 
     config.getApiClassConfig().getMethods()
         .get(methodToEndpointMethod(TestEndpoint.class.getMethod("getResultNoParams")))
-        .addParameter("param", null, false, null, TypeToken.of(Integer.class))
+        .addParameter("param", null, false, null, TypeToken.of(Integer.class), null)
         .setSerializer(TestSerializer.class);
 
     try {
@@ -223,7 +223,7 @@ public class ApiConfigValidatorTest {
 
     config.getApiClassConfig().getMethods()
         .get(methodToEndpointMethod(TestEndpoint.class.getMethod("getResultNoParams")))
-        .addParameter("param", null, false, null, TypeToken.of(Integer[].class))
+        .addParameter("param", null, false, null, TypeToken.of(Integer[].class), null)
         .setRepeatedItemSerializer(TestSerializer.class);
 
     try {
@@ -271,7 +271,7 @@ public class ApiConfigValidatorTest {
 
     config.getApiClassConfig().getMethods()
         .get(methodToEndpointMethod(TestEndpoint.class.getMethod("getResultNoParams")))
-        .addParameter("param", null, false, null, TypeToken.of(Integer.class))
+        .addParameter("param", null, false, null, TypeToken.of(Integer.class), null)
         .setSerializer((Class<? extends Transformer<?, ?>>) (Class<?>) TestSerializer.class);
 
     try {
@@ -287,7 +287,7 @@ public class ApiConfigValidatorTest {
 
     config.getApiClassConfig().getMethods()
         .get(methodToEndpointMethod(TestEndpoint.class.getMethod("getResultNoParams")))
-        .addParameter("param", null, false, null, TypeToken.of(Integer[].class))
+        .addParameter("param", null, false, null, TypeToken.of(Integer[].class), null)
         .setRepeatedItemSerializer(
             (Class<? extends Transformer<?, ?>>) (Class<?>) TestSerializer.class);
 
@@ -308,7 +308,7 @@ public class ApiConfigValidatorTest {
         .get(methodToEndpointMethod(TestEndpoint.class.getMethod("getResultNoParams")))
         .addParameter("param", null, false, null,
             TypeToken.of(
-                Foo.class.getDeclaredMethod("foo", List.class).getGenericParameterTypes()[0]));
+                Foo.class.getDeclaredMethod("foo", List.class).getGenericParameterTypes()[0]), null);
 
     try {
       validator.validate(config);
@@ -327,7 +327,7 @@ public class ApiConfigValidatorTest {
         .get(methodToEndpointMethod(TestEndpoint.class.getMethod("getResultNoParams")))
         .addParameter("param", null, false, null,
             TypeToken.of(
-                Foo.class.getDeclaredMethod("foo", List[].class).getGenericParameterTypes()[0]));
+                Foo.class.getDeclaredMethod("foo", List[].class).getGenericParameterTypes()[0]), null);
 
     try {
       validator.validate(config);
@@ -346,7 +346,7 @@ public class ApiConfigValidatorTest {
         .get(methodToEndpointMethod(TestEndpoint.class.getMethod("getResultNoParams")))
         .addParameter("param", null, false, null,
             TypeToken.of(
-                Foo.class.getDeclaredMethod("foo", List.class).getGenericParameterTypes()[0]));
+                Foo.class.getDeclaredMethod("foo", List.class).getGenericParameterTypes()[0]), null);
 
     try {
       validator.validate(config);
@@ -359,7 +359,7 @@ public class ApiConfigValidatorTest {
   public void testArrayOfArraysParameter() throws Exception {
     config.getApiClassConfig().getMethods()
         .get(methodToEndpointMethod(TestEndpoint.class.getMethod("getResultNoParams")))
-        .addParameter("param", null, false, null, TypeToken.of(Integer[][].class));
+        .addParameter("param", null, false, null, TypeToken.of(Integer[][].class), null);
 
     try {
       validator.validate(config);
@@ -379,7 +379,7 @@ public class ApiConfigValidatorTest {
 
     config.getApiClassConfig().getMethods()
         .get(methodToEndpointMethod(TestEndpoint.class.getMethod("getResultNoParams")))
-        .addParameter("param", null, false, null, unknownType);
+        .addParameter("param", null, false, null, unknownType, null);
 
     try {
       validator.validate(config);

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/config/validation/ApiConfigValidatorTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/config/validation/ApiConfigValidatorTest.java
@@ -207,7 +207,7 @@ public class ApiConfigValidatorTest {
 
     config.getApiClassConfig().getMethods()
         .get(methodToEndpointMethod(TestEndpoint.class.getMethod("getResultNoParams")))
-        .addParameter("param", null, false, null, TypeToken.of(Integer.class), null, null)
+        .addParameter("param", null, false, null, TypeToken.of(Integer.class), null)
         .setSerializer(TestSerializer.class);
 
     try {
@@ -223,7 +223,7 @@ public class ApiConfigValidatorTest {
 
     config.getApiClassConfig().getMethods()
         .get(methodToEndpointMethod(TestEndpoint.class.getMethod("getResultNoParams")))
-        .addParameter("param", null, false, null, TypeToken.of(Integer[].class), null, null)
+        .addParameter("param", null, false, null, TypeToken.of(Integer[].class), null)
         .setRepeatedItemSerializer(TestSerializer.class);
 
     try {
@@ -271,7 +271,7 @@ public class ApiConfigValidatorTest {
 
     config.getApiClassConfig().getMethods()
         .get(methodToEndpointMethod(TestEndpoint.class.getMethod("getResultNoParams")))
-        .addParameter("param", null, false, null, TypeToken.of(Integer.class), null, null)
+        .addParameter("param", null, false, null, TypeToken.of(Integer.class), null)
         .setSerializer((Class<? extends Transformer<?, ?>>) (Class<?>) TestSerializer.class);
 
     try {
@@ -287,7 +287,7 @@ public class ApiConfigValidatorTest {
 
     config.getApiClassConfig().getMethods()
         .get(methodToEndpointMethod(TestEndpoint.class.getMethod("getResultNoParams")))
-        .addParameter("param", null, false, null, TypeToken.of(Integer[].class), null, null)
+        .addParameter("param", null, false, null, TypeToken.of(Integer[].class), null)
         .setRepeatedItemSerializer(
             (Class<? extends Transformer<?, ?>>) (Class<?>) TestSerializer.class);
 
@@ -308,7 +308,7 @@ public class ApiConfigValidatorTest {
         .get(methodToEndpointMethod(TestEndpoint.class.getMethod("getResultNoParams")))
         .addParameter("param", null, false, null,
             TypeToken.of(
-                Foo.class.getDeclaredMethod("foo", List.class).getGenericParameterTypes()[0]), null, null);
+                Foo.class.getDeclaredMethod("foo", List.class).getGenericParameterTypes()[0]), null);
 
     try {
       validator.validate(config);
@@ -327,7 +327,7 @@ public class ApiConfigValidatorTest {
         .get(methodToEndpointMethod(TestEndpoint.class.getMethod("getResultNoParams")))
         .addParameter("param", null, false, null,
             TypeToken.of(
-                Foo.class.getDeclaredMethod("foo", List[].class).getGenericParameterTypes()[0]), null, null);
+                Foo.class.getDeclaredMethod("foo", List[].class).getGenericParameterTypes()[0]), null);
 
     try {
       validator.validate(config);
@@ -346,7 +346,7 @@ public class ApiConfigValidatorTest {
         .get(methodToEndpointMethod(TestEndpoint.class.getMethod("getResultNoParams")))
         .addParameter("param", null, false, null,
             TypeToken.of(
-                Foo.class.getDeclaredMethod("foo", List.class).getGenericParameterTypes()[0]), null, null);
+                Foo.class.getDeclaredMethod("foo", List.class).getGenericParameterTypes()[0]), null);
 
     try {
       validator.validate(config);
@@ -359,7 +359,7 @@ public class ApiConfigValidatorTest {
   public void testArrayOfArraysParameter() throws Exception {
     config.getApiClassConfig().getMethods()
         .get(methodToEndpointMethod(TestEndpoint.class.getMethod("getResultNoParams")))
-        .addParameter("param", null, false, null, TypeToken.of(Integer[][].class), null, null);
+        .addParameter("param", null, false, null, TypeToken.of(Integer[][].class), null);
 
     try {
       validator.validate(config);
@@ -379,7 +379,7 @@ public class ApiConfigValidatorTest {
 
     config.getApiClassConfig().getMethods()
         .get(methodToEndpointMethod(TestEndpoint.class.getMethod("getResultNoParams")))
-        .addParameter("param", null, false, null, unknownType, null, null);
+        .addParameter("param", null, false, null, unknownType, null);
 
     try {
       validator.validate(config);

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/config/validation/ApiConfigValidatorTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/config/validation/ApiConfigValidatorTest.java
@@ -207,7 +207,7 @@ public class ApiConfigValidatorTest {
 
     config.getApiClassConfig().getMethods()
         .get(methodToEndpointMethod(TestEndpoint.class.getMethod("getResultNoParams")))
-        .addParameter("param", null, false, null, TypeToken.of(Integer.class), null)
+        .addParameter("param", null, false, null, TypeToken.of(Integer.class), null, null)
         .setSerializer(TestSerializer.class);
 
     try {
@@ -223,7 +223,7 @@ public class ApiConfigValidatorTest {
 
     config.getApiClassConfig().getMethods()
         .get(methodToEndpointMethod(TestEndpoint.class.getMethod("getResultNoParams")))
-        .addParameter("param", null, false, null, TypeToken.of(Integer[].class), null)
+        .addParameter("param", null, false, null, TypeToken.of(Integer[].class), null, null)
         .setRepeatedItemSerializer(TestSerializer.class);
 
     try {
@@ -271,7 +271,7 @@ public class ApiConfigValidatorTest {
 
     config.getApiClassConfig().getMethods()
         .get(methodToEndpointMethod(TestEndpoint.class.getMethod("getResultNoParams")))
-        .addParameter("param", null, false, null, TypeToken.of(Integer.class), null)
+        .addParameter("param", null, false, null, TypeToken.of(Integer.class), null, null)
         .setSerializer((Class<? extends Transformer<?, ?>>) (Class<?>) TestSerializer.class);
 
     try {
@@ -287,7 +287,7 @@ public class ApiConfigValidatorTest {
 
     config.getApiClassConfig().getMethods()
         .get(methodToEndpointMethod(TestEndpoint.class.getMethod("getResultNoParams")))
-        .addParameter("param", null, false, null, TypeToken.of(Integer[].class), null)
+        .addParameter("param", null, false, null, TypeToken.of(Integer[].class), null, null)
         .setRepeatedItemSerializer(
             (Class<? extends Transformer<?, ?>>) (Class<?>) TestSerializer.class);
 
@@ -308,7 +308,7 @@ public class ApiConfigValidatorTest {
         .get(methodToEndpointMethod(TestEndpoint.class.getMethod("getResultNoParams")))
         .addParameter("param", null, false, null,
             TypeToken.of(
-                Foo.class.getDeclaredMethod("foo", List.class).getGenericParameterTypes()[0]), null);
+                Foo.class.getDeclaredMethod("foo", List.class).getGenericParameterTypes()[0]), null, null);
 
     try {
       validator.validate(config);
@@ -327,7 +327,7 @@ public class ApiConfigValidatorTest {
         .get(methodToEndpointMethod(TestEndpoint.class.getMethod("getResultNoParams")))
         .addParameter("param", null, false, null,
             TypeToken.of(
-                Foo.class.getDeclaredMethod("foo", List[].class).getGenericParameterTypes()[0]), null);
+                Foo.class.getDeclaredMethod("foo", List[].class).getGenericParameterTypes()[0]), null, null);
 
     try {
       validator.validate(config);
@@ -346,7 +346,7 @@ public class ApiConfigValidatorTest {
         .get(methodToEndpointMethod(TestEndpoint.class.getMethod("getResultNoParams")))
         .addParameter("param", null, false, null,
             TypeToken.of(
-                Foo.class.getDeclaredMethod("foo", List.class).getGenericParameterTypes()[0]), null);
+                Foo.class.getDeclaredMethod("foo", List.class).getGenericParameterTypes()[0]), null, null);
 
     try {
       validator.validate(config);
@@ -359,7 +359,7 @@ public class ApiConfigValidatorTest {
   public void testArrayOfArraysParameter() throws Exception {
     config.getApiClassConfig().getMethods()
         .get(methodToEndpointMethod(TestEndpoint.class.getMethod("getResultNoParams")))
-        .addParameter("param", null, false, null, TypeToken.of(Integer[][].class), null);
+        .addParameter("param", null, false, null, TypeToken.of(Integer[][].class), null, null);
 
     try {
       validator.validate(config);
@@ -379,7 +379,7 @@ public class ApiConfigValidatorTest {
 
     config.getApiClassConfig().getMethods()
         .get(methodToEndpointMethod(TestEndpoint.class.getMethod("getResultNoParams")))
-        .addParameter("param", null, false, null, unknownType, null);
+        .addParameter("param", null, false, null, unknownType, null, null);
 
     try {
       validator.validate(config);

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/discovery/DiscoveryGeneratorTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/discovery/DiscoveryGeneratorTest.java
@@ -46,6 +46,7 @@ import com.google.api.server.spi.testing.NonDiscoverableEndpoint;
 import com.google.api.server.spi.testing.OptionalEndpoint;
 import com.google.api.server.spi.testing.PrimitiveEndpoint;
 import com.google.api.server.spi.testing.RequiredPropertiesEndpoint;
+import com.google.api.server.spi.testing.ValidationEndpoint;
 import com.google.api.services.discovery.model.DirectoryList;
 import com.google.api.services.discovery.model.RestDescription;
 import com.google.common.collect.ImmutableList;
@@ -299,6 +300,13 @@ public class DiscoveryGeneratorTest {
     ApiConfig config = configLoader.loadConfiguration(ServiceContext.create(), FooEndpoint.class);
     DiscoveryGenerator.Result result = generator.writeDiscovery(ImmutableList.of(config), context);
     result.directory().clone();
+  }
+
+  @Test
+  public void testWriteDiscovery_ValidationEndpoint() throws Exception {
+    RestDescription doc = getDiscovery(new DiscoveryContext(), ValidationEndpoint.class);
+    RestDescription expected = readExpectedAsDiscovery("validation_endpoint.json");
+    compareDiscovery(expected, doc);
   }
 
   private RestDescription getDiscovery(DiscoveryContext context, Class<?> serviceClass)

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/swagger/SwaggerGeneratorTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/swagger/SwaggerGeneratorTest.java
@@ -58,6 +58,7 @@ import com.google.api.server.spi.testing.OptionalEndpoint;
 import com.google.api.server.spi.testing.RequiredPropertiesEndpoint;
 import com.google.api.server.spi.testing.SpecialCharsEndpoint;
 import com.google.api.server.spi.testing.ResponseStatusEndpoint;
+import com.google.api.server.spi.testing.ValidationEndpoint;
 import com.google.common.collect.ImmutableList;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -381,6 +382,13 @@ public class SwaggerGeneratorTest {
     Swagger swagger = generator.writeSwagger(ImmutableList.of(config), context
         .setExtractCommonParametersAsRefs(true));
     Swagger expected = readExpectedAsSwagger("special_chars.swagger");
+    checkSwagger(expected, swagger);
+  }
+  
+  @Test
+  public void testWriteSwagger_ValidationEndpoint() throws Exception {
+    Swagger swagger = getSwagger(ValidationEndpoint.class, new SwaggerContext());
+    Swagger expected = readExpectedAsSwagger("validation_endpoint.swagger");
     checkSwagger(expected, swagger);
   }
 

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/discovery/validation_endpoint.json
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/discovery/validation_endpoint.json
@@ -25,6 +25,8 @@
       "id": "validation.create",
       "parameterOrder": [
         "pathParam",
+        "decimalMinMaxParam",
+        "minMaxParam",
         "queryParam"
       ],
       "parameters": {
@@ -39,7 +41,24 @@
           "required": true,
           "type": "string",
           "pattern": "^[a-z]{2}$"
+        },
+        "minMaxParam": {
+          "location": "query",
+          "required": true,
+          "type": "string",
+          "format" : "int64",
+          "minimum": "10",
+          "maximum": "20"
+        },
+        "decimalMinMaxParam": {
+          "location": "query",
+          "required": true,
+          "type": "number",
+          "format": "double",
+          "minimum": "2.3",
+          "maximum": "4"
         }
+        
       },
       "path": "{pathParam}",
       "scopes": [

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/discovery/validation_endpoint.json
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/discovery/validation_endpoint.json
@@ -1,0 +1,100 @@
+{
+  "auth": {
+    "oauth2": {
+      "scopes": {
+        "https://www.googleapis.com/auth/userinfo.email": {
+          "description": "View your email address"
+        }
+      }
+    }
+  },
+  "basePath": "/_ah/api/validation/v1/",
+  "baseUrl": "https://myapi.appspot.com/_ah/api/validation/v1/",
+  "batchPath": "batch",
+  "description": "This is an API",
+  "discoveryVersion": "v1",
+  "icons": {
+    "x16": "https://www.gstatic.com/images/branding/product/1x/googleg_16dp.png",
+    "x32": "https://www.gstatic.com/images/branding/product/1x/googleg_32dp.png"
+  },
+  "id": "validation:v1",
+  "kind": "discovery#restDescription",
+  "methods": {
+    "create": {
+      "httpMethod": "POST",
+      "id": "validation.create",
+      "parameterOrder": [
+        "pathParam",
+        "queryParam"
+      ],
+      "parameters": {
+        "pathParam": {
+          "location": "path",
+          "required": true,
+          "type": "string",
+          "pattern": "^\\d+$"
+        },
+        "queryParam": {
+          "location": "query",
+          "required": true,
+          "type": "string",
+          "pattern": "^[a-z]{2}$"
+        }
+      },
+      "path": "{pathParam}",
+      "scopes": [
+        "https://www.googleapis.com/auth/userinfo.email"
+      ]
+    }
+  },
+  "name": "validation",
+  "parameters": {
+    "alt": {
+      "default": "json",
+      "description": "Data format for the response.",
+      "enum": [
+        "json"
+      ],
+      "enumDescriptions": [
+        "Responses with Content-Type of application/json"
+      ],
+      "location": "query",
+      "type": "string"
+    },
+    "fields": {
+      "description": "Selector specifying which fields to include in a partial response.",
+      "location": "query",
+      "type": "string"
+    },
+    "key": {
+      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
+      "location": "query",
+      "type": "string"
+    },
+    "oauth_token": {
+      "description": "OAuth 2.0 token for the current user.",
+      "location": "query",
+      "type": "string"
+    },
+    "prettyPrint": {
+      "default": "true",
+      "description": "Returns response with indentations and line breaks.",
+      "location": "query",
+      "type": "boolean"
+    },
+    "quotaUser": {
+      "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.",
+      "location": "query",
+      "type": "string"
+    },
+    "userIp": {
+      "description": "IP address of the site where the request originates. Use this if you want to enforce per-user limits.",
+      "location": "query",
+      "type": "string"
+    }
+  },
+  "protocol": "rest",
+  "rootUrl": "https://myapi.appspot.com/_ah/api/",
+  "servicePath": "validation/v1/",
+  "version": "v1"
+}

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/validation_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/validation_endpoint.swagger
@@ -41,6 +41,23 @@
             "required": true,
             "type": "string",
             "pattern": "^[a-z]{2}$"
+          }, 
+          {
+            "name" : "minMaxParam",
+            "in" : "query",
+            "required" : true,
+            "type" : "integer",
+            "format" : "int64",
+            "minimum": 10,
+            "maximum": 20
+          }, {
+            "name" : "decimalMinMaxParam",
+            "in" : "query",
+            "required" : true,
+            "type" : "number",
+            "format" : "double",
+            "minimum": 2.3,
+            "maximum": 4
           }
         ],
         "responses": {

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/validation_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/validation_endpoint.swagger
@@ -1,0 +1,54 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "myapi.appspot.com"
+  },
+  "host": "myapi.appspot.com",
+  "basePath": "/_ah/api",
+  "tags": [
+    {
+      "name": "validation:v1"
+    }
+  ],
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/validation/v1/{pathParam}": {
+      "post": {
+        "tags": [
+          "validation:v1"
+        ],
+        "operationId": "validation:v1.create",
+        "parameters": [
+          {
+            "name": "pathParam",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "^\\d+$"
+          },
+          {
+            "name": "queryParam",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-z]{2}$"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description" : "A successful response"
+          }
+        }
+      }
+    }
+  }
+}

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/validation_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/validation_endpoint.swagger
@@ -57,7 +57,9 @@
             "type" : "number",
             "format" : "double",
             "minimum": 2.3,
-            "maximum": 4
+            "exclusiveMinimum" : true,
+            "maximum": 4,
+            "exclusiveMaximum" : false
           }
         ],
         "responses": {

--- a/test-utils/src/main/java/com/google/api/server/spi/testing/ValidationEndpoint.java
+++ b/test-utils/src/main/java/com/google/api/server/spi/testing/ValidationEndpoint.java
@@ -32,6 +32,6 @@ public class ValidationEndpoint {
           @Named("pathParam") @Pattern(regexp = "^\\d+$") String pathParam, 
           @Named("queryParam") @Pattern(regexp = "^[a-z]{2}$") String queryParam,
           @Named("minMaxParam") @Min(10) @Max(20) Long minMaxParam,
-          @Named("decimalMinMaxParam") @DecimalMin(value = "2.3") @DecimalMax(value = "4") Double decimalMinMaxParam) {
+          @Named("decimalMinMaxParam") @DecimalMin(value = "2.3", inclusive = false) @DecimalMax(value = "4") Double decimalMinMaxParam) {
   }
 }

--- a/test-utils/src/main/java/com/google/api/server/spi/testing/ValidationEndpoint.java
+++ b/test-utils/src/main/java/com/google/api/server/spi/testing/ValidationEndpoint.java
@@ -15,6 +15,10 @@
  */
 package com.google.api.server.spi.testing;
 
+import javax.validation.constraints.DecimalMax;
+import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.Pattern;
 
 import com.google.api.server.spi.config.Api;
@@ -26,6 +30,8 @@ public class ValidationEndpoint {
   @ApiMethod(name = "create", path = "{pathParam}")
   public void create(
           @Named("pathParam") @Pattern(regexp = "^\\d+$") String pathParam, 
-          @Named("queryParam") @Pattern(regexp = "^[a-z]{2}$") String queryParam) {
+          @Named("queryParam") @Pattern(regexp = "^[a-z]{2}$") String queryParam,
+          @Named("minMaxParam") @Min(10) @Max(20) Long minMaxParam,
+          @Named("decimalMinMaxParam") @DecimalMin(value = "2.3") @DecimalMax(value = "4") Double decimalMinMaxParam) {
   }
 }

--- a/test-utils/src/main/java/com/google/api/server/spi/testing/ValidationEndpoint.java
+++ b/test-utils/src/main/java/com/google/api/server/spi/testing/ValidationEndpoint.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.server.spi.testing;
+
+import javax.validation.constraints.Pattern;
+
+import com.google.api.server.spi.config.Api;
+import com.google.api.server.spi.config.ApiMethod;
+import com.google.api.server.spi.config.Named;
+
+@Api(name = "validation", version = "v1")
+public class ValidationEndpoint {
+  @ApiMethod(name = "create", path = "{pathParam}")
+  public void create(
+          @Named("pathParam") @Pattern(regexp = "^\\d+$") String pathParam, 
+          @Named("queryParam") @Pattern(regexp = "^[a-z]{2}$") String queryParam) {
+  }
+}


### PR DESCRIPTION
Fills pattern/minimum/maximum attributes in both Discovery and Swagger description formats from javax.validation.constraints enums (Pattern, Min, Max, DecimalMin, DecimalMax).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aodocs/endpoints-java/60)
<!-- Reviewable:end -->
